### PR TITLE
Fixed Broken Stackoverflow Go Link

### DIFF
--- a/faq/readme.md
+++ b/faq/readme.md
@@ -48,7 +48,7 @@ If you're experiencing a bug with the code, or have an idea for how it can be im
 
 [gcloud-cli]: https://cloud.google.com/sdk/gcloud/
 
-[so-java]: http://stackoverflow.com/questions/tagged/gcloud-go
+[so-golang]: http://stackoverflow.com/questions/tagged/gcloud-go
 [so-java]: http://stackoverflow.com/questions/tagged/gcloud-java
 [so-node]: http://stackoverflow.com/questions/tagged/gcloud-node
 [so-python]: http://stackoverflow.com/questions/tagged/gcloud-python


### PR DESCRIPTION
The gcloud-go link was mislabeled as gcloud-java causing the markdown to render incorrectly as well as direct the user to incorrect content.