### PR TITLE
Adding some optional / reduced scopes to auth doc.

### DIFF
--- a/authorization/readme.md
+++ b/authorization/readme.md
@@ -8,9 +8,11 @@ If you are running this client on Google Compute Engine, we handle authorization
 
   * **All APIs**
     * `https://www.googleapis.com/auth/cloud-platform`
+    * `https://www.googleapis.com/auth/cloud-platform.read-only`
 
   * **BigQuery**
     * `https://www.googleapis.com/auth/bigquery`
+    * `https://www.googleapis.com/auth/bigquery.insertdata`
   * **Compute Engine**
     * `https://www.googleapis.com/auth/compute`
   * **Datastore**
@@ -25,6 +27,8 @@ If you are running this client on Google Compute Engine, we handle authorization
     * `https://www.googleapis.com/auth/userinfo.email`
   * **Storage**
     * `https://www.googleapis.com/auth/devstorage.full_control`
+    * `https://www.googleapis.com/auth/devstorage.read_only`
+    * `https://www.googleapis.com/auth/devstorage.read_write`
 
 ## On Your Own Server
 


### PR DESCRIPTION
Also remove the email scope from datastore. It's in the discovery doc but doesn't actually work.

@pcostell Can you confirm that `email` scope doesn't work? I noticed it's not even included in https://www.googleapis.com/discovery/v1/apis/datastore/v1beta3/rest

----

Sources for updating scope lists:

https://www.googleapis.com/discovery/v1/apis/bigquery/v2/rest
https://www.googleapis.com/discovery/v1/apis/datastore/v1beta2/rest
https://www.googleapis.com/discovery/v1/apis/datastore/v1beta3/rest
https://www.googleapis.com/discovery/v1/apis/pubsub/v1/rest
https://www.googleapis.com/discovery/v1/apis/storage/v1/rest
