### PR TITLE
site: always use https resources

### DIFF
--- a/site/src/app/index.scss
+++ b/site/src/app/index.scss
@@ -5,8 +5,8 @@
 // bower:scss
 // endbower
 
-@import url(http://fonts.googleapis.com/css?family=Droid+Sans+Mono|Roboto:300,400,700,700italic,400italic|Open+Sans:300);
-@import url(http://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css);
+@import url(https://fonts.googleapis.com/css?family=Droid+Sans+Mono|Roboto:300,400,700,700italic,400italic|Open+Sans:300);
+@import url(https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css);
 
 /**
  *  Do not remove this comments bellow. It's the markers used by gulp-inject to inject


### PR DESCRIPTION
Currently, [the site](https://googlecloudplatform.github.io/gcloud-node/#/docs/v0.27.0/gcloud) gets a few errors in the console:

> Mixed Content: The page at 'https://googlecloudplatform.github.io/gcloud-node/#/docs/v0.27.0/gcloud' was loaded over HTTPS, but requested an insecure stylesheet 'http://fonts.googleapis.com/css?family=Droid+Sans+Mono|Roboto:300,400,700,700italic,400italic|Open+Sans:300'. This request has been blocked; the content must be served over HTTPS.
(index):1

> Mixed Content: The page at 'https://googlecloudplatform.github.io/gcloud-node/#/docs/v0.27.0/gcloud' was loaded over HTTPS, but requested an insecure stylesheet 'http://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css'. This request has been blocked; the content must be served over HTTPS.

This PR changes the offending resources to always use the secure endpoint.

Also, I think we should wait to merge this PR until we get #35 done, since this will be a good test to see if it works!