### PR TITLE
docs build: install gulp-cli (not gulp)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - "0.12"
 before_script:
-  - npm install -g bower gulp
+  - npm install -g bower gulp-cli
 script: "./deploy-docs.sh"
 env:
   global:

--- a/deploy-docs.sh
+++ b/deploy-docs.sh
@@ -28,7 +28,7 @@ fi
 function deploy_docs {
   # Install dependencies & run the build (minify, concatenate dependencies, etc.)
   cd site
-  npm install --loglevel verbose & bower install
+  npm install --loglevel info & bower install
   gulp build
 
   # Pull down the target client library's gh-pages branch.


### PR DESCRIPTION
It's now `gulp-cli`, not `gulp`: https://github.com/gulpjs/gulp/blob/master/docs/getting-started.md

And `verbose` logging was much too verbose.