### PR TITLE
docs build: turn down npm verbosity

### DIFF
--- a/deploy-docs.sh
+++ b/deploy-docs.sh
@@ -28,7 +28,7 @@ fi
 function deploy_docs {
   # Install dependencies & run the build (minify, concatenate dependencies, etc.)
   cd site
-  npm install --loglevel info
+  npm install
   bower install
   gulp build
 


### PR DESCRIPTION
Travis stopped printing the log, so apparently it is still too verbose.