### PR TITLE
docs: mobile bug fixes

### DIFF
--- a/site/src/app/docs/docs.html
+++ b/site/src/app/docs/docs.html
@@ -17,7 +17,7 @@
 
   <section ui-view></section>
 
-  <nav class="side-nav">
+  <nav class="side-nav visible-lg">
     <version-switcher></version-switcher>
     <ul class="page-sections external-links" ng-if="docs.guides.length">
       <li>

--- a/site/src/app/styles/_main.scss
+++ b/site/src/app/styles/_main.scss
@@ -431,6 +431,7 @@ ul {
 .language-switcher--home .menu {
     position: absolute;
     bottom: initial;
+    z-index: 1;
 }
 
 .page-header.fixed .menu {


### PR DESCRIPTION
Fixes a few small layout issues for mobile

* Hides main navigation (it was showing up at the bottom)
* Stops icon overlapping on landing page when menu is open