### PR TITLE
site: add service resources links

### DIFF
--- a/site/src/app/service/service.html
+++ b/site/src/app/service/service.html
@@ -19,6 +19,14 @@
   <article ng-if="service.metadata.description">
     <h3>{{::service.metadata.name}} Overview</h3>
     <div bind-html-compile="service.metadata.description"></div>
+    <section ng-if="service.metadata.resources.length">
+      <h4>More Information</h4>
+      <ul class="resource-links">
+        <li ng-repeat="resource in service.metadata.resources">
+          <a ng-href="{{resource.link}}">{{resource.title}}</a>
+        </li>
+      </ul>
+    </section>
   </article>
   <article ng-repeat="method in service.methods">
     <h2 ng-if="method.metadata.isConstructor">{{::method.metadata.name}}</h2>


### PR DESCRIPTION
This PR adds a list of `resource.link` & `resource.title` pairs for services/classes. This is to support [the gcloud-ruby docs JSON](https://github.com/quartzmo/gcloud-ruby/blob/gh-pages/json/master/bigquery/table.json), which includes many such links, as shown in this example fragment:

```js
{
  id: "table",
  metadata: {
    name: "Table",
    description: "<h1 id="table">Table</h1> <p>A named resource representing a BigQuery table that holds zero or more records. Every table is defined by a schema that may contain nested and repeated fields.</p>",
    source: "lib/gcloud/bigquery/table.rb#L66",
    resources: [
      {
        title: "Preparing Data for BigQuery",
        link: "https://cloud.google.com/bigquery/preparing-data-for-bigquery"
      }
    ],
    ...
```

I put this section just after the description and before the method listings. For me, it's a part of the top-level overview/description. If you put it after the methods, readers interested in "the big picture" probably won't get the info.

I tested this locally with gcloud-ruby JSON, LGTM.
