### PR TITLE
docs: preserve version on custom type links

### DIFF
--- a/site/src/app/components/custom-type/custom-type.directive.js
+++ b/site/src/app/components/custom-type/custom-type.directive.js
@@ -7,11 +7,13 @@
 
   /** @ngInject */
   function customType($state, manifest) {
-
     var convertToServicePath = function(customType) {
       var parts = customType.split('#');
       var stateName = 'docs.service';
-      var stateParams = { serviceId: parts[0] };
+      var stateParams = {
+        serviceId: parts[0],
+        version: $state.params.version
+      };
       var stateOptions = { inherit: false };
 
       if (parts.length > 1) {
@@ -31,7 +33,7 @@
       link: function (scope, elem, attrs) {
         var customType = attrs.customType;
         if (elem.html().length === 0) {
-          elem.html(customType) // Set path as text if no text in element
+          elem.html(customType); // Set path as text if no text in element
         }
         elem.addClass('skip-external-link')
           .attr('href', converter(customType.replace('[]', '')));


### PR DESCRIPTION
Closes #92 

@quartzmo caught a bug where clicking a custom-type directive link would redirect the user to the latest version, this change will preserve the version.