### PR TITLE
docs: update routing logic to not skip homepage

### DIFF
--- a/site/src/app/docs/docs.route.js
+++ b/site/src/app/docs/docs.route.js
@@ -59,14 +59,21 @@
     $urlRouterProvider.when('/docs', goToGcloud);
 
     $urlRouterProvider.otherwise(function($injector, $location) {
-      var baseUrl = '/docs/';
+      var path = $location.path();
+      var docsBaseUrl = '/docs/';
+      var isUnknownRoute = path.indexOf(docsBaseUrl) === -1;
+
+      if (isUnknownRoute) {
+        return '/';
+      }
+
       var versions = $injector.get('manifest').versions;
-      var params = $location.path().replace(baseUrl, '').split('/');
+      var params = path.replace(docsBaseUrl, '').split('/');
       var isValidVersion = versions.indexOf(params[0]) !== -1;
 
       // could be a bad service name
       if (isValidVersion) {
-        return baseUrl + params[0];
+        return docsBaseUrl + params[0];
       }
 
       // could be a version alias
@@ -77,7 +84,7 @@
         params.unshift(latestVersion);
       }
 
-      return baseUrl + params.join('/');
+      return docsBaseUrl + params.join('/');
     });
   }
 

--- a/site/src/app/home/home.route.js
+++ b/site/src/app/home/home.route.js
@@ -6,7 +6,7 @@
     .config(homeRoutes);
 
   /** @ngInject */
-  function homeRoutes(manifest, $stateProvider, $urlRouterProvider) {
+  function homeRoutes(manifest, $stateProvider) {
     $stateProvider.state('home', {
       url: '/',
       templateUrl: 'app/home/home.html',
@@ -14,8 +14,6 @@
       controllerAs: 'home',
       resolve: { latestRelease: getLatestRelease }
     });
-
-    $urlRouterProvider.otherwise('/');
   }
 
   /** @ngInject */


### PR DESCRIPTION
Closes #91 

For whatever reason `/` and `/#` do not match the home route, so when we would hit said routes, they would redirect the user to the latest docs page. 

Good catch, @stephenplusplus!