### PR TITLE
Add method type to service template

### DIFF
--- a/site/src/app/docs/docs.service.js
+++ b/site/src/app/docs/docs.service.js
@@ -14,6 +14,8 @@
       if (method.metadata) {
         method.metadata.description = $sce.trustAsHtml(method.metadata.description);
         method.metadata.isConstructor = method.metadata.constructor === true;
+        method.metadata.anchor = getMethodAnchor(method.metadata);
+        method.metadata.typeSymbol = getMethodTypeSymbol(method.metadata.type);
 
         if (method.metadata.examples) {
           method.metadata.examples = method.metadata.examples.map(trustExample);
@@ -65,6 +67,22 @@
       param.description = $sce.trustAsHtml(param.description);
 
       return param;
+    }
+
+    function getMethodAnchor(metadata) {
+      var anchor = metadata.name;
+      if (metadata.type) {
+        anchor += "-type-" + metadata.type;
+      }
+      return anchor;
+    }
+
+    function getMethodTypeSymbol(type) {
+      var typeSymbol = "#";
+      if (type === "class") {
+        typeSymbol = ".";
+      }
+      return typeSymbol;
     }
 
     return {

--- a/site/src/app/service/service.html
+++ b/site/src/app/service/service.html
@@ -30,9 +30,9 @@
   </article>
   <article ng-repeat="method in service.methods">
     <h2 ng-if="method.metadata.isConstructor">{{::method.metadata.name}}</h2>
-    <h3 id="{{::method.metadata.name}}" ng-if="!method.metadata.isConstructor" class="method-heading">
-      <a class="permalink" ui-sref="docs.service({ method: method.metadata.name })">
-        <span>#</span>
+    <h3 id="{{::method.metadata.anchor}}" ng-if="!method.metadata.isConstructor" class="method-heading">
+      <a class="permalink" ui-sref="docs.service({ method: method.metadata.anchor })">
+        <span>{{::method.metadata.typeSymbol}}</span>
         {{::method.metadata.name}}
       </a>
     </h3>


### PR DESCRIPTION
This PR addresses the potential for name conflicts between instance and class methods in Ruby. We actually have a number of methods in the `Gcloud` module that share the same name, so this problem is not hypothetical. See #80 for discussion.

Previously, page anchors were broken for these methods. In the demo for this PR, navigation to the `bigquery` [instance method](http://quartzmo.github.io/gcloud-ruby/#/docs/master/gcloud?method=bigquery) and  [class method](http://quartzmo.github.io/gcloud-ruby/#/docs/master/gcloud?method=bigquery-type-class) now both work.

I'm not really thrilled about the direction I took with this solution. I was hoping to introduce `type` as a parameter to the Services controller, but it would require more changes (to `DeeplinkService`, `customType`, etc)  than I was comfortable making without feedback/input. 

@callmehiphop I would be more than happy to throw away this PR if you can suggest or submit a better solution.

/cc @blowmage @stephenplusplus


