### PR TITLE
site: updates to consume new json schemas

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -12,19 +12,22 @@
   * [`versions`][versions-key]
   * [`content`][content-key]
   * [`home`][home-key]
+  * [`package`][package-key]
+* [Table of Contents][toc]
   * [`overview`][overview-key]
   * [`guides`][guides-key]
   * [`services`][services-key]
-  * [`package`][package-key]
+* [Types][types]
+  * [`types`][types-key]
 * [JSON Docs Schema][json-schema]
   * [`id`][id-key]
   * [`description` and `caption`][description-keys]
-  * [`metadata`][metadata-key]
+  * [Misc. keys][misc-keys]
   * [`methods`][methods-key]
-    * [`metadata`][metadata-key-1]
     * [`params`][params-key]
     * [`exceptions`][exceptions-key]
     * [`returns`][returns-key]
+    * [Misc. keys][misc-keys-1]
   * [Custom Data Types][custom-types]
 * [Misc. Content][misc-content]
   * [Landing Page][landing-page]
@@ -74,6 +77,8 @@ gcloud-common/site/src
  ├─── assets # images, etc.
  ├─── versions # JSON content folder
  |     └─── v0.28.0 # one folder per release
+ |           ├─── toc.json # table of contents for this version
+ |           ├─── types.json # list of custom types for this version
  |           └─── storage # one folder per service
  |                 ├─── index.json # one file per class/module/etc.
  |                 └─── bucket.json
@@ -163,6 +168,27 @@ For the landing page of the documentation, it was decided (*see [gcloud-common#4
 
 See the [Landing Page section][landing-page] for more information.
 
+##### `package` key
+
+This allows you to specify what package manager you use and a direct link to your package.
+
+```js
+{
+  "package": {
+    "title": "npm",
+    "href": "https://www.npmjs.com/package/gcloud"
+  }
+}
+```
+
+See the [JSON Docs Schema section][json-schema] for more information.
+
+## Table of Contents
+
+The <kbd>toc.json</kbd> file is used to create the primary navigation component, it also maps JSON content to custom data types that may not be accessible via main navigation.
+
+For each version folder you have, there should be a corresponding <kbd>toc.json</kbd> file located within said folder.
+
 ##### `overview` key
 
 **Note:** *This field is completely optional.*
@@ -203,40 +229,46 @@ Optionally you can also provide an `edit` field, which should map to a URL that 
 
 The services section is very similar to the [guides section][guides-key]. This key will act as a table of contents for the *API* section of the documentation site. Instead of markdown, this section of the docs is driven by [JSON][json-schema].
 
-Since there is only a single manifest for all versions (at least for now) you can add a key called `implemented` to specify what versions this service is available in.
+The `type` key should map to an object within the [`types`][types-key] array.
 
 You can also create nested sections for the various service concepts via `nav` key. The objects that occupy the `nav` array match that of the `service` array.
 
 ```js
 {
   "services": [{
-    "title": "title": "Storage",
-    "id": "storage",
-    "implemented": ">=0.10.0",
-    "contents": "storage/index.json",
+    "title": "Storage",
+    "type": "storage",
     "nav": [{
       "title": "Bucket",
-      "id": "bucket",
-      "contents": "storage/bucket.json"
+      "type": "storage/bucket"
     }]
   }]
 }
 ```
 
-##### `package` key
+## Types
 
-This allows you to specify what package manager you use and a direct link to your package.
+The types section lists all the available data types for the application. All types should be placed within the <kbd>types.json</kbd> file.
+
+##### `types` key
+
+The `id` key will be used to map content from urls - `/docs/v0.28.0/storage/bucket` will map to `"id": "storage/bucket"`
+
+The `title` key will be used to create a title on the service page.
 
 ```js
 {
-  "package": {
-    "title": "npm",
-    "href": "https://www.npmjs.com/package/gcloud"
-  }
+  "types": [{
+    "title": "Storage",
+    "id": "storage",
+    "contents": "storage/index.json"
+  }, {
+    "title": "Storage » Bucket",
+    "id": "storage/bucket",
+    "contents": "storage/bucket.json"
+  }]
 }
 ```
-
-See the [JSON Docs Schema section][json-schema] for more information.
 
 ## JSON Docs Schema
 
@@ -262,20 +294,18 @@ Throughout the JSON structure there will be several instances of the `descriptio
 }
 ```
 
-##### `metadata` key
+##### Misc. keys
 
-The top-level metadata object contains a friendly name for the service. Optionally you can provide a service description and external links.
+The top-level object contains a friendly name for the service. Optionally you can provide a service description and external links.
 
 ```js
 {
-  "metadata": {
-    "name": "Storage",
-    "description": "<p>Storage is cool!</p>", // optional
-    "resources": [{ // optional
-      "title": "Storage Overview",
-      "link": "https://storage-is-cool.com"
-    }]
-  }
+  "name": "Storage",
+  "description": "<p>Storage is cool!</p>", // optional
+  "resources": [{ // optional
+    "title": "Storage Overview",
+    "link": "https://storage-is-cool.com"
+  }]
 }
 ```
 
@@ -286,35 +316,9 @@ This field defines all the methods available for this service. Methods contain m
 ```js
 {
   "methods": [{
-    "metadata": {},
     "params": [],
     "exceptions": [],
     "returns": []
-  }]
-}
-```
-
-###### `metadata` key
-
-This field is similar to the top-level metadata field, however it can also include several other items to better describe a method (examples, source code, etc.)
-
-```js
-{
-  "methods": [{
-    "metadata": {
-      "constructor": false, // we document constructors/modules in the same fashion as methods
-      "name": "createBucket", // method name -> Storage#createBucket
-      "source": "/lib/storage/index.js#L270", // github path for deeplinking
-      "description": "<p>Create a bucket.</p>",
-      "examples": [{ // list of examples
-        "caption": "<p>Here's how you would create a bucket!</p>", // caption for example
-        "code": "storage.createBucket('new-bucket', callback);" // example code
-      }],
-      "resources": [{ // list of external resources
-        "title": "Buckets: insert API docs",
-        "link": "https://storage-is-cool.com/create-buckets/"
-      }]
-    }
   }]
 }
 ```
@@ -379,6 +383,30 @@ This field is optional, when present it should contain a list of return values.
 }
 ```
 
+###### Misc. keys
+
+This field is similar to the top-level metadata field, however it can also include several other items to better describe a method (examples, source code, etc.)
+
+```js
+{
+  "methods": [{
+    "type": "constructor", // we document constructors/modules in the same fashion as methods
+    "id": "storage#createBucket", // unique ID for method
+    "name": "createBucket", // method name -> Storage#createBucket
+    "source": "/lib/storage/index.js#L270", // github path for deeplinking
+    "description": "<p>Create a bucket.</p>",
+    "examples": [{ // list of examples
+      "caption": "<p>Here's how you would create a bucket!</p>", // caption for example
+      "code": "storage.createBucket('new-bucket', callback);" // example code
+    }],
+    "resources": [{ // list of external resources
+      "title": "Buckets: insert API docs",
+      "link": "https://storage-is-cool.com/create-buckets/"
+    }]
+  }]
+}
+```
+
 ### Custom Data Types
 
 In some cases you may need to link to custom data types, this can happen pretty much anywhere (descriptions, param types, return types, exception types, etc.). If this is functionality that you need, you can instead return an `<a>` tag using a custom data attribute `custom-type`.
@@ -421,22 +449,13 @@ See a living example of gcloud-node's home template [here][gcloud-node-home].
 
 ##### Overview Section
 
-Specify an overview using the <kbd>manifest.json</kbd>'s [`overview` key][overview-key].
+Specify an overview using the <kbd>toc.json</kbd>'s [`overview` key][overview-key].
 
 Overviews are completely optional, you can create one using html.
 
 See [gcloud-node docs][gcloud-node-docs] for a working demo. The contents of the overview file fill the *Getting Started with gcloud* section of the service pages.
 
 See a living example of gcloud-node's overview template [here][gcloud-node-overview].
-
-##### Custom Page Headers
-
-Different languages may wish for different formatting when it comes to page titles, when moving to the common-docs you can design a [template][page-header-template] to display the title how you wish.
-
-A `title` array containing the name hierarchy will be available for you.
-
-When visiting `/docs/latest/storage` the `title` array will resemble `['Storage']`.
-When visiting `/docs/latest/storage/bucket` the `title` array will resemble `['Storage', 'Bucket']`.
 
 ## Deploying
 
@@ -467,9 +486,9 @@ Please refer to gcloud-node's [`gh-pages` branch][gcloud-node-ghpages] for an ex
 [json-schema]: #json-docs-schema
 [id-key]: #id-key
 [description-keys]: #description-and-caption-keys
-[metadata-key]: #metadata-key
+[misc-keys]: #misc-keys
 [methods-key]: #methods-key
-[metadata-key-1]: #metadata-key-1
+[misc-keys-1]: #misc-keys-1
 [params-key]: #params-key
 [exceptions-key]: #exceptions-key
 [returns-key]: #returns-key
@@ -479,6 +498,9 @@ Please refer to gcloud-node's [`gh-pages` branch][gcloud-node-ghpages] for an ex
 [overview-section]: #overview-section
 [custom-page-headers]: #custom-page-headers
 [deploying]: #deploying
+[toc]: #table-of-contents
+[types]: #types
+[types-key]: #types-key
 
 [nodejs]: https://nodejs.org/en/
 [hljs]: https://highlightjs.org/

--- a/site/bower.json
+++ b/site/bower.json
@@ -7,7 +7,6 @@
     "normalize-css": "normalize.css#~3.0.3",
     "highlightjs": "~9.0.0",
     "angular-highlightjs": "~0.5.1",
-    "showdown": "~1.3.0",
-    "semver": "~4.3.4"
+    "showdown": "~1.3.0"
   }
 }

--- a/site/schemas/manifest.schema.json
+++ b/site/schemas/manifest.schema.json
@@ -37,129 +37,6 @@
       "type": "string",
       "description": "Path to landing page content"
     },
-    "overview": {
-      "id": "overview",
-      "type": "string",
-      "description": "Optional content to be injected at the top of service pages"
-    },
-    "guides": {
-      "id": "guides",
-      "type": "array",
-      "description": "Table of contents for the Getting Started section",
-      "items": {
-        "id": "guide",
-        "type": "object",
-        "description": "Object that describes a Guide",
-        "properties": {
-          "title": {
-            "id": "title",
-            "type": "string",
-            "description": "Name of the guide as it should appear in the Navigation"
-          },
-          "id": {
-            "id": "id",
-            "type": "string",
-            "description": "Guide id used for routing and mapping JSON content"
-          },
-          "edit": {
-            "id": "edit",
-            "type": "string",
-            "description": "URL to Github edit page for supplied markdown"
-          },
-          "contents": {
-            "id": "contents",
-            "type": ["array", "string"],
-            "description": "List of markdown files to display",
-            "items": [
-              {
-                "id": "guide_url",
-                "type": "string",
-                "description": "Path to markdown file, if it does not begin with http(s), it's assumed to be a local file"
-              }
-            ]
-          }
-        },
-        "required": [
-          "title",
-          "id",
-          "contents"
-        ]
-      }
-    },
-    "services": {
-      "id": "services",
-      "type": "array",
-      "description": "Table of contents for the API section",
-      "items": {
-        "id": "service",
-        "type": "object",
-        "description": "Object that describes a service",
-        "properties": {
-          "title": {
-            "id": "title",
-            "type": "string",
-            "description": "Name of the Service as it should appear in the side navigation"
-          },
-          "id": {
-            "id": "id",
-            "type": "string",
-            "description": "Service id used for routing and mapping JSON content"
-          },
-          "implemented": {
-            "id": "implemented",
-            "type": "string",
-            "description": "Semver version indicating when this service was first available"
-          },
-          "contents": {
-            "id": "contents",
-            "type": "string",
-            "description": "Path to service JSON content"
-          },
-          "nav": {
-            "id": "nav",
-            "type": "array",
-            "description": "Concepts to be nested within the Service, e.g. Storage -> Bucket",
-            "items": {
-              "id": "sub-service",
-              "type": "object",
-              "description": "Object describing the sub-service",
-              "properties": {
-                "title": {
-                  "id": "title",
-                  "type": "string",
-                  "description": "Name of the sub-service as it should appear in the side navigation"
-                },
-                "id": {
-                  "id": "id",
-                  "type": "string",
-                  "description": "Sub-service id used for routing and mapping JSON content"
-                },
-                "implemented": {
-                  "id": "implemented",
-                  "type": "string",
-                  "description": "Semver version indicating when this service was first available"
-                },
-                "contents": {
-                  "id": "contents",
-                  "type": "string",
-                  "description": "Path to sub-service JSON content"
-                }
-              },
-              "required": [
-                "title",
-                "id",
-                "contents"
-              ]
-            }
-          }
-        },
-        "required": [
-          "title",
-          "id",
-          "contents"
-        ]
-      }
-    },
     "package": {
       "id": "package",
       "type": "object",
@@ -189,8 +66,6 @@
     "versions",
     "content",
     "home",
-    "guides",
-    "services",
     "package"
   ]
 }

--- a/site/schemas/service.schema.json
+++ b/site/schemas/service.schema.json
@@ -7,51 +7,41 @@
       "type": "string",
       "description": "Service id"
     },
-    "metadata": {
-      "id": "metadata",
-      "type": "object",
-      "description": "Misc. information relating to the service",
-      "properties": {
-        "name": {
-          "id": "name",
-          "type": "string",
-          "description": "User friendly name of the service"
-        },
-        "description": {
-          "id": "description",
-          "type": "string",
-          "description": "Brief overview of the service"
-        },
-        "resources": {
-          "id": "resources",
-          "type": "array",
-          "description": "List of links that relate to the service",
-          "items": {
-            "id": "resource",
-            "type": "object",
-            "description": "Object that describes a resource",
-            "properties": {
-              "title": {
-                "id": "title",
-                "type": "string",
-                "description": "User friendly text describing the resource"
-              },
-              "link": {
-                "id": "link",
-                "type": "string",
-                "description": "URL for the resource"
-              }
-            },
-            "required": [
-              "title",
-              "link"
-            ]
+    "name": {
+      "id": "name",
+      "type": "string",
+      "description": "User friendly name of the service"
+    },
+    "description": {
+      "id": "description",
+      "type": "string",
+      "description": "Brief overview of the service"
+    },
+    "resources": {
+      "id": "resources",
+      "type": "array",
+      "description": "List of links that relate to the service",
+      "items": {
+        "id": "resource",
+        "type": "object",
+        "description": "Object that describes a resource",
+        "properties": {
+          "title": {
+            "id": "title",
+            "type": "string",
+            "description": "User friendly text describing the resource"
+          },
+          "link": {
+            "id": "link",
+            "type": "string",
+            "description": "URL for the resource"
           }
-        }
-      },
-      "required": [
-        "name"
-      ]
+        },
+        "required": [
+          "title",
+          "link"
+        ]
+      }
     },
     "methods": {
       "id": "methods",
@@ -61,84 +51,78 @@
         "id": "method",
         "type": "object",
         "properties": {
-          "metadata": {
-            "id": "metadata",
-            "type": "object",
-            "description": "Misc. information relating to the method",
-            "properties": {
-              "constructor": {
-                "id": "constructor",
-                "type": "boolean",
-                "description": "Signifies whether or not this method is a constructor (constructors are treated the same as methods)"
-              },
-              "name": {
-                "id": "name",
-                "type": "string",
-                "description": "The name of the method"
-              },
-              "source": {
-                "id": "source",
-                "type": "string",
-                "description": "Relative path to the source file of the method, including the line number"
-              },
-              "description": {
-                "id": "description",
-                "type": "string",
-                "description": "Brief overview of the method"
-              },
-              "examples": {
-                "id": "examples",
-                "type": "array",
-                "description": "List of examples showing how the method is used",
-                "items": {
-                  "id": "example",
-                  "type": "object",
-                  "description": "Object describing an example",
-                  "properties": {
-                    "caption": {
-                      "id": "caption",
-                      "type": "string",
-                      "description": "Caption explaining what the example is attempting to accomplish"
-                    },
-                    "code": {
-                      "id": "code",
-                      "type": "string",
-                      "description": "Code snippet showing how the method can be used"
-                    }
-                  }
-                }
-              },
-              "resources": {
-                "id": "resources",
-                "type": "array",
-                "description": "List of links relating to the method",
-                "items": {
-                  "id": "resource",
-                  "type": "object",
-                  "description": "Object describing the resource",
-                  "properties": {
-                    "title": {
-                      "id": "title",
-                      "type": "string",
-                      "description": "The resource title text"
-                    },
-                    "link": {
-                      "id": "link",
-                      "type": "string",
-                      "description": "The resource link URL"
-                    }
-                  },
-                  "required": [
-                    "title",
-                    "link"
-                  ]
+          "id": {
+            "id": "id",
+            "type": "string",
+            "description": "Unique ID used to identify the method"
+          },
+          "type": {
+            "id": "type",
+            "type": "string",
+            "description": "Signifies what kind of method this is (static, instance, constructor)"
+          },
+          "name": {
+            "id": "name",
+            "type": "string",
+            "description": "The name of the method"
+          },
+          "source": {
+            "id": "source",
+            "type": "string",
+            "description": "Relative path to the source file of the method, including the line number"
+          },
+          "description": {
+            "id": "description",
+            "type": "string",
+            "description": "Brief overview of the method"
+          },
+          "examples": {
+            "id": "examples",
+            "type": "array",
+            "description": "List of examples showing how the method is used",
+            "items": {
+              "id": "example",
+              "type": "object",
+              "description": "Object describing an example",
+              "properties": {
+                "caption": {
+                  "id": "caption",
+                  "type": "string",
+                  "description": "Caption explaining what the example is attempting to accomplish"
+                },
+                "code": {
+                  "id": "code",
+                  "type": "string",
+                  "description": "Code snippet showing how the method can be used"
                 }
               }
-            },
-            "required": [
-              "name",
-              "source"
-            ]
+            }
+          },
+          "resources": {
+            "id": "resources",
+            "type": "array",
+            "description": "List of links relating to the method",
+            "items": {
+              "id": "resource",
+              "type": "object",
+              "description": "Object describing the resource",
+              "properties": {
+                "title": {
+                  "id": "title",
+                  "type": "string",
+                  "description": "The resource title text"
+                },
+                "link": {
+                  "id": "link",
+                  "type": "string",
+                  "description": "The resource link URL"
+                }
+              },
+              "required": [
+                "title",
+                "link"
+              ]
+            }
           },
           "params": {
             "id": "params",
@@ -222,10 +206,15 @@
               "type": "object",
               "description": "Object describing the return value",
               "properties": {
-                "type": {
-                  "id": "type",
-                  "type": "string",
-                  "description": "The return value type, e.g. String, Number, etc."
+                "types": {
+                  "id": "types",
+                  "type": "array",
+                  "description": "List of the possible return values",
+                  "items": {
+                    "id": "type",
+                    "type": "string",
+                    "description": "Name of the data type"
+                  }
                 },
                 "description": {
                   "id": "description",
@@ -234,20 +223,22 @@
                 }
               },
               "required": [
-                "type"
+                "types"
               ]
             }
           }
         },
         "required": [
-          "metadata"
+          "id",
+          "name",
+          "source"
         ]
       }
     }
   },
   "required": [
     "id",
-    "metadata",
+    "name",
     "methods"
   ]
 }

--- a/site/schemas/toc.schema.json
+++ b/site/schemas/toc.schema.json
@@ -1,0 +1,111 @@
+{
+  "id": "toc",
+  "type": "object",
+  "properties": {
+    "overview": {
+      "id": "overview",
+      "type": "string",
+      "description": "Optional content to be injected at the top of service pages"
+    },
+    "guides": {
+      "id": "guides",
+      "type": "array",
+      "description": "Table of contents for the Getting Started section",
+      "items": {
+        "id": "guide",
+        "type": "object",
+        "description": "Object that describes a Guide",
+        "properties": {
+          "title": {
+            "id": "title",
+            "type": "string",
+            "description": "Name of the guide as it should appear in the Navigation"
+          },
+          "id": {
+            "id": "id",
+            "type": "string",
+            "description": "Guide id used for routing and mapping JSON content"
+          },
+          "edit": {
+            "id": "edit",
+            "type": "string",
+            "description": "URL to Github edit page for supplied markdown"
+          },
+          "contents": {
+            "id": "contents",
+            "type": ["array", "string"],
+            "description": "List of markdown files to display",
+            "items": [
+              {
+                "id": "guide_url",
+                "type": "string",
+                "description": "Path to markdown file, if it does not begin with http(s), it's assumed to be a local file"
+              }
+            ]
+          }
+        },
+        "required": [
+          "title",
+          "id",
+          "contents"
+        ]
+      }
+    },
+    "services": {
+      "id": "services",
+      "type": "array",
+      "description": "Table of contents for the API section",
+      "items": {
+        "id": "service",
+        "type": "object",
+        "description": "Object that describes a service",
+        "properties": {
+          "title": {
+            "id": "title",
+            "type": "string",
+            "description": "Name of the service as it should appear in the side navigation"
+          },
+          "type": {
+            "id": "type",
+            "type": "string",
+            "description": "ID of type that maps JSON content"
+          },
+          "nav": {
+            "id": "nav",
+            "type": "array",
+            "description": "Concepts to be nested within the Service, e.g. Storage -> Bucket",
+            "items": {
+              "id": "sub-service",
+              "type": "object",
+              "description": "Object describing the sub-service",
+              "properties": {
+                "title": {
+                  "id": "title",
+                  "type": "string",
+                  "description": "Name of the sub-service as it should appear in the side navigation"
+                },
+                "type": {
+                  "id": "type",
+                  "type": "string",
+                  "description": "ID of type that maps JSON content"
+                }
+              },
+              "required": [
+                "title",
+                "type"
+              ]
+            }
+          }
+        },
+        "required": [
+          "title",
+          "type"
+        ]
+      }
+    }
+  },
+  "required": [
+    "guides",
+    "services"
+  ]
+}

--- a/site/schemas/types.schema.json
+++ b/site/schemas/types.schema.json
@@ -1,0 +1,31 @@
+{
+  "id": "types",
+  "type": "array",
+  "description": "List of custom data types available within this version",
+  "items": {
+    "id": "type",
+    "type": "object",
+    "description": "Object describing the data type",
+    "properties": {
+      "id": {
+        "id": "id",
+        "type": "string",
+        "description": "ID used to map custom types to JSON content"
+      },
+      "title": {
+        "id": "title",
+        "type": "string",
+        "description": "Name of the datatype as it should appear in the overview"
+      },
+      "contents": {
+        "id": "contents",
+        "type": "string",
+        "description": "Path to datatype JSON content"
+      }
+    },
+    "required": [
+      "id",
+      "contents"
+    ]
+  }
+}

--- a/site/src/app/components/page-header/page-header.directive.js
+++ b/site/src/app/components/page-header/page-header.directive.js
@@ -5,31 +5,18 @@
     .module('gcloud')
     .directive('pageHeader', pageHeader);
 
-  var templates = {
-    node: '{{title ? title.join(" » ") : "Node.js"}}',
-    ruby: '{{title ? title.join("::") : "Ruby"}}'
-  };
-
   /** @ngInject */
   function pageHeader(manifest) {
     return {
       restrict: 'E',
+      templateUrl: 'app/components/page-header/page-header.html',
       replace: true,
       transclude: true,
       scope: {
         title: '='
       },
-      template: function() {
-        return '<header class="docs-header">' +
-          '<div class="row">' +
-            '<div class="col-60 margin-vertical">' +
-              '<h1 class="page-title">' +
-                templates[manifest.lang] +
-              '</h1>' +
-            '</div>' +
-            '<div class="col-40" ng-transclude></div>' +
-          '</div>' +
-        '</header>';
+      link: function(scope) {
+        scope.title = scope.title || manifest.friendlyLang;
       }
     };
   }

--- a/site/src/app/components/page-header/page-header.html
+++ b/site/src/app/components/page-header/page-header.html
@@ -1,0 +1,8 @@
+<header class="docs-header">
+  <div class="row">
+    <div class="col-60 margin-vertical">
+      <h1 class="page-title">{{::title}}</h1>
+    </div>
+    <div class="col-40" ng-transclude></div>
+  </div>
+</header>

--- a/site/src/app/docs/docs.controller.js
+++ b/site/src/app/docs/docs.controller.js
@@ -1,4 +1,3 @@
-/* global semver:true */
 (function() {
   'use strict';
 
@@ -7,14 +6,13 @@
     .controller('DocsCtrl', DocsCtrl);
 
   /** @ngInject */
-  function DocsCtrl($state, langs, manifest, lastBuiltDate) {
+  function DocsCtrl($state, langs, manifest, toc, lastBuiltDate) {
     var docs = this;
 
     docs.langs = langs;
     docs.lastBuiltDate = lastBuiltDate;
-    docs.guides = angular.copy(manifest.guides).filter(isAvailable);
-    docs.services = angular.copy(manifest.services).filter(isAvailable);
-    docs.services.forEach(updateNav);
+    docs.guides = toc.guides;
+    docs.services = toc.services;
     docs.version = $state.params.version;
     docs.overviewFileUrl = null;
 
@@ -23,11 +21,11 @@
     docs.getGuideUrl = getGuideUrl;
     docs.isActive = isActive;
 
-    if (manifest.overview) {
+    if (toc.overview) {
       docs.overviewFileUrl = [
         manifest.content,
         $state.params.version,
-        manifest.overview
+        toc.overview
       ].join('/');
     }
 
@@ -41,22 +39,6 @@
 
     function getGuideUrl(page) {
       return page.title.toLowerCase().replace(/\s/g, '-');
-    }
-
-    function isAvailable(service) {
-      var version = $state.params.version;
-
-      if (version === 'master') {
-        return true;
-      }
-
-      return semver.satisfies(version, service.implemented || '*');
-    }
-
-    function updateNav(service) {
-      if (service.nav) {
-        service.nav = service.nav.filter(isAvailable);
-      }
     }
   }
 }());

--- a/site/src/app/docs/docs.html
+++ b/site/src/app/docs/docs.html
@@ -32,10 +32,10 @@
         <h4 class="list-item--heading">API</h4>
       </li>
       <li ng-repeat="service in docs.services">
-        <a side-nav-link="/{{service.id}}">{{service.title || service.id}}</a>
-        <ul class="sub-sections" ng-if="service.nav && docs.isActive(service.id)">
+        <a side-nav-link="/{{service.type}}">{{service.title || service.type}}</a>
+        <ul class="sub-sections" ng-if="service.nav && docs.isActive(service.type)">
           <li ng-repeat="page in service.nav">
-            <a side-nav-link="/{{service.id}}/{{page.id}}">{{page.title || page.id}}</a>
+            <a side-nav-link="/{{page.type}}">{{page.title || page.type}}</a>
           </li>
         </ul>
       </li>

--- a/site/src/app/docs/docs.service.js
+++ b/site/src/app/docs/docs.service.js
@@ -11,13 +11,14 @@
     function setAsTrusted(_method) {
       var method = angular.copy(_method);
 
-      if (method.metadata) {
-        method.metadata.description = $sce.trustAsHtml(method.metadata.description);
-        method.metadata.isConstructor = method.metadata.constructor === true;
+      method.isConstructor = method.type === 'constructor';
 
-        if (method.metadata.examples) {
-          method.metadata.examples = method.metadata.examples.map(trustExample);
-        }
+      if (method.description) {
+        method.description = $sce.trustAsHtml(method.description);
+      }
+
+      if (method.examples) {
+        method.examples = method.examples.map(trustExample);
       }
 
       if (method.returns) {
@@ -68,7 +69,8 @@
     }
 
     return {
-      setAsTrusted: setAsTrusted
+      setAsTrusted: setAsTrusted,
+      trust: $sce.trustAsHtml.bind($sce)
     };
   }
 

--- a/site/src/app/guide/guide.controller.js
+++ b/site/src/app/guide/guide.controller.js
@@ -9,7 +9,7 @@
   function GuideCtrl($scope, $state, $sce, $interpolate, guideObject, manifest, DeeplinkService, util) {
     var guide = this;
 
-    guide.title = [guideObject.title];
+    guide.title = guideObject.title;
     guide.contents = util.arrify(guideObject.contents).map(trustContent);
     guide.editUrl = guideObject.edit ? trustContent(guideObject.edit) : null;
 

--- a/site/src/app/service/service.controller.js
+++ b/site/src/app/service/service.controller.js
@@ -9,16 +9,19 @@
   function ServiceCtrl($scope, $state, DeeplinkService, DocsService, serviceObject) {
     var service = this;
 
-    service.methods = serviceObject.methods.map(DocsService.setAsTrusted).sort(sortMethods);
-    service.metadata = DocsService.setAsTrusted(serviceObject || {}).metadata;
+    angular.extend(service, DocsService.setAsTrusted(serviceObject));
+
+    service.methods = serviceObject.methods
+      .map(DocsService.setAsTrusted)
+      .sort(sortMethods);
+
     service.methodNames = service.methods.map(getName);
-    service.title = serviceObject.metadata.title;
     service.showGettingStarted = false;
 
     $scope.$on('$viewContentLoaded', watchMethod);
 
     function getName(method) {
-      return method.metadata.name;
+      return method.name;
     }
 
     function watchMethod() {
@@ -30,18 +33,15 @@
     }
 
     function sortMethods(a, b) {
-      if (a.metadata.constructor) {
+      if (a.type === 'constructor') {
         return -1;
       }
 
-      if (b.metadata.constructor) {
+      if (b.type === 'constructor') {
         return 1;
       }
 
-      var aName = a.metadata.name;
-      var bName = b.metadata.name;
-
-      return +(aName > bName) || +(aName === bName) - 1;
+      return +(a.name > b.name) || +(a.name === b.name) - 1;
     }
   }
 }());

--- a/site/src/app/service/service.html
+++ b/site/src/app/service/service.html
@@ -16,33 +16,31 @@
       ng-include="docs.overviewFileUrl"></article>
     <hr />
   </div>
-  <article ng-if="service.metadata.description">
-    <h3>{{::service.metadata.name}} Overview</h3>
-    <div bind-html-compile="service.metadata.description"></div>
-    <section ng-if="service.metadata.resources.length">
+  <article ng-if="service.description || service.resources.length">
+    <h3>{{::service.name}} Overview</h3>
+    <div ng-if="service.description" bind-html-compile="service.description"></div>
+    <section ng-if="service.resources.length">
       <h4>More Information</h4>
       <ul class="resource-links">
-        <li ng-repeat="resource in service.metadata.resources">
+        <li ng-repeat="resource in service.resources">
           <a ng-href="{{resource.link}}">{{resource.title}}</a>
         </li>
       </ul>
     </section>
   </article>
   <article ng-repeat="method in service.methods">
-    <h2 ng-if="method.metadata.isConstructor">{{::method.metadata.name}}</h2>
-    <h3 id="{{::method.metadata.name}}" ng-if="!method.metadata.isConstructor" class="method-heading">
-      <a class="permalink" ui-sref="docs.service({ method: method.metadata.name })">
+    <h2 ng-if="method.isConstructor">{{::method.name}}</h2>
+    <h3 id="{{::method.name}}" ng-if="!method.isConstructor" class="method-heading">
+      <a class="permalink" ui-sref="docs.service({ method: method.name })">
         <span>#</span>
-        {{::method.metadata.name}}
+        {{::method.name}}
       </a>
     </h3>
-    <div bind-html-compile="method.metadata.description"></div>
-    <div ng-if="method.metadata.isConstructor" class="notice">
+    <div bind-html-compile="method.description"></div>
+    <div ng-if="method.isConstructor" class="notice">
       Available methods:
       <span ng-repeat="method in service.methods">
-        <span ng-if="!method.metadata.isConstructor">
-          <a ui-sref="docs.service({ method: method.metadata.name })">{{method.metadata.name}}</a>{{$last ? '' : ', '}}
-        </span>
+        <a ui-sref="docs.service({ method: method.name })">{{method.name}}</a>{{$last ? '' : ', '}}
       </span>
     </div>
     <section ng-if="method.params.length">
@@ -67,9 +65,9 @@
       <h4>Returns</h4>
       <p bind-html-compile="method.returns[0]"></p>
     </section>
-    <section ng-if="method.metadata.examples.length">
+    <section ng-if="method.examples.length">
       <h4>Example</h4>
-      <div ng-repeat="example in method.metadata.examples">
+      <div ng-repeat="example in method.examples">
         <div ng-if="example.caption" bind-html-compile="example.caption"></div>
         <div ng-if="example.code" class="code-block">
           <pre><code class="hljs" bind-html-compile="example.code"></code></pre>
@@ -80,9 +78,9 @@
       <h4>More Information</h4>
       <ul class="resource-links">
         <li>
-          <a ng-href="https://github.com/GoogleCloudPlatform/gcloud-{{lang}}/blob/{{docs.version}}/{{method.metadata.source}}">Source Code</a>
+          <a ng-href="https://github.com/GoogleCloudPlatform/gcloud-{{lang}}/blob/{{docs.version}}/{{method.source}}">Source Code</a>
         </li>
-        <li ng-repeat="resource in method.metadata.resources">
+        <li ng-repeat="resource in method.resources">
           <a ng-href="{{resource.link}}">{{resource.title}}</a>
         </li>
       </ul>


### PR DESCRIPTION
Closes https://github.com/GoogleCloudPlatform/gcloud-common/issues/77
Closes https://github.com/GoogleCloudPlatform/gcloud-common/issues/78

This PR aims to give support to some of the requested features needed by both gcloud-ruby and gcloud-php.

[demo](http://callmehiphop.github.io/gcloud-node/#/docs/master/gcloud)
[source files (unminified)](https://github.com/callmehiphop/gcloud-node/tree/gh-pages)

---
#### Notable Changes:

* Create a Table of Contents JSON file per version and remove Semver logic
* Tweak code to allow for hidden types
* Remove `metadata` field
* Move `title` key for service overview pages to the <kbd>toc.json</kbd>
* Align JSON more with @blowmage's [schema proposals](https://gist.github.com/blowmage/13be352f40ee7ac5ee48)

---

#### TODOS:

- [x] Split Manifest JSON - https://github.com/GoogleCloudPlatform/gcloud-common/issues/77
- [x] Separate Code data from Navigation - https://github.com/GoogleCloudPlatform/gcloud-common/issues/78
- [x] Create unique IDs for ALL THE THINGS! - https://github.com/GoogleCloudPlatform/gcloud-common/issues/79
- [x] Add support for method types (constructor, instance, static, etc.) https://github.com/GoogleCloudPlatform/gcloud-common/issues/80
- [x] Update documentation to reflect changes - [demo](https://github.com/callmehiphop/gcloud-common/blob/json-updates/site/README.md)
- [x] Update Schemas files
- [x] Move `types` to separate JSON file
- [x] Update gcloud-nodes JSON - https://github.com/GoogleCloudPlatform/gcloud-node/pull/1167
- [x] Update docs for <kbd>types.json</kbd>

/cc @blowmage @quartzmo @dwsupplee 