### PR TITLE
Custom method type symbols

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -13,6 +13,7 @@
   * [`content`][content-key]
   * [`home`][home-key]
   * [`package`][package-key]
+  * [`methodTypeSymbols`][methodtypesymbols-key]
 * [Table of Contents][toc]
   * [`overview`][overview-key]
   * [`guides`][guides-key]
@@ -178,6 +179,25 @@ This allows you to specify what package manager you use and a direct link to you
     "title": "npm",
     "href": "https://www.npmjs.com/package/gcloud"
   }
+}
+```
+
+##### `methodTypeSymbols` key
+
+This optional list allows you to map language-specific method type names (such as `instance` or `static`) to labels or symbols displayed in the method listing (such as `#`.) If not provided, the pound sign (`#`) will be used for all method types.
+
+```js
+{
+  "methodTypeSymbols": [
+    {
+      "type": "class",
+      "symbol": "::"
+    },
+    {
+      "type": "instance",
+      "symbol": "#"
+    }
+  ]
 }
 ```
 

--- a/site/schemas/manifest.schema.json
+++ b/site/schemas/manifest.schema.json
@@ -57,6 +57,32 @@
         "title",
         "href"
       ]
+    },
+    "methodTypeSymbols": {
+      "id": "methodTypeSymbols",
+      "type": "array",
+      "description": "List of mappings from method types to display symbols",
+      "items": {
+        "id": "methodTypeSymbol",
+        "type": "object",
+        "description": "Maps a method type ('instance') to a symbol ('#')",
+        "properties": {
+          "type": {
+            "id": "type",
+            "type": "string",
+            "description": "The language-specific type name of the method"
+          },
+          "symbol": {
+            "id": "symbol",
+            "type": "string",
+            "description": "The language-specific symbol for the method type"
+          }
+        },
+        "required": [
+          "type",
+          "symbol"
+        ]
+      }
     }
   },
   "required": [

--- a/site/src/app/docs/docs.service.js
+++ b/site/src/app/docs/docs.service.js
@@ -7,11 +7,13 @@
     .factory('DocsService', DocsService);
 
   /** @ngInject */
-  function DocsService($sce, manifest) {
+  function DocsService($sce, manifest, util) {
     function setAsTrusted(_method) {
       var method = angular.copy(_method);
 
       method.isConstructor = method.type === 'constructor';
+
+      method.typeSymbol = getTypeSymbol(method.type);
 
       if (method.description) {
         method.description = $sce.trustAsHtml(method.description);
@@ -30,6 +32,19 @@
       }
 
       return method;
+    }
+
+    function getTypeSymbol(methodType) {
+      var typeSymbol = '#';
+      if (methodType && manifest.methodTypeSymbols) {
+        var mapping = util.findWhere(manifest.methodTypeSymbols, {
+          type: methodType
+        });
+        if (mapping) {
+          typeSymbol = mapping.symbol;
+        }
+      }
+      return typeSymbol;
     }
 
     function trustReturn(returnValue) {

--- a/site/src/app/service/service.html
+++ b/site/src/app/service/service.html
@@ -32,7 +32,7 @@
     <h2 ng-if="method.isConstructor">{{::method.name}}</h2>
     <h3 id="{{::method.name}}" ng-if="!method.isConstructor" class="method-heading">
       <a class="permalink" ui-sref="docs.service({ method: method.name })">
-        <span>#</span>
+        <span>{{::method.typeSymbol}}</span>
         {{::method.name}}
       </a>
     </h3>


### PR DESCRIPTION
This PR visibly differentiates methods by `type` with a custom, runtime-configured string (symbol or other label.) 

[Demo](http://quartzmo.github.io/gcloud-ruby/#/docs/master/gcloud)

[refs #80]

The PR depends on a new (optional) `methodTypeSymbols` field in `manifest.json`, which maps display characters to method types. (For example: `#` for `instance`.)

This PR replaces outdated #100. 