### PR TITLE
site: update Ruby code highlight style

### DIFF
--- a/site/src/app/styles/_ruby.scss
+++ b/site/src/app/styles/_ruby.scss
@@ -1,3 +1,9 @@
+pre.ruby {
+  background-color: #f8f8f8;
+  padding: 0.5em;
+  font-size: 1em;
+  color: #333;
+}
 pre.ruby .hll { background-color: #f8f8f8 }
 pre.ruby .c { color: #998; font-style: italic } /* Comment */
 pre.ruby .err { color: #a61717; background-color: #e3d2d2 } /* Error */


### PR DESCRIPTION
This change to Ruby code example highlighting, which involves nothing more than a few lines of CSS, is a possible solution to GoogleCloudPlatform/gcloud-ruby#583 ("Code highlighting style in markdown does not match gcloud-common site".)

The change does not seek to perfectly match the Highlight.js Ruby styling, which is rudimentary and inferior to that of Pygments' Ruby highlighting. It simply adjusts a few values, most notably background color, to provide visual cohesion with the Highlight.js examples.

[Demo](http://quartzmo.github.io/gcloud-ruby/#/docs/master/gcloud/bigquery)

Illustration: Pygments (left, with this change) and Highlight.js (right).

![pygments-new-background](https://cloud.githubusercontent.com/assets/205445/13884997/0d402978-ecf6-11e5-9664-d4b43d7e3514.png)

/cc @blowmage @jgeewax