### PR TITLE
site: support links to method ids

### DIFF
--- a/site/src/app/components/custom-type/custom-type.directive.js
+++ b/site/src/app/components/custom-type/custom-type.directive.js
@@ -6,27 +6,17 @@
     .directive('customType', customType);
 
   /** @ngInject */
-  function customType($state, manifest) {
+  function customType($state) {
     var convertToServicePath = function(customType) {
-      var parts = customType.split('#');
       var stateName = 'docs.service';
       var stateParams = {
-        serviceId: parts[0],
+        serviceId: customType,
         version: $state.params.version
       };
       var stateOptions = { inherit: false };
 
-      if (parts.length > 1) {
-        stateParams.method = parts[1];
-      }
-
       return $state.href(stateName, stateParams, stateOptions);
     };
-
-    var converter = {
-      node: convertToServicePath,
-      ruby: convertToServicePath
-    }[manifest.lang];
 
     return {
       restrict: 'A',
@@ -36,7 +26,7 @@
           elem.html(customType); // Set path as text if no text in element
         }
         elem.addClass('skip-external-link')
-          .attr('href', converter(customType.replace('[]', '')));
+          .attr('href', convertToServicePath(customType.replace('[]', '')));
       }
     };
   }

--- a/site/src/app/components/side-nav-link/side-nav-link.directive.js
+++ b/site/src/app/components/side-nav-link/side-nav-link.directive.js
@@ -25,7 +25,9 @@
         }
 
         function toggleClass(currentHref) {
-          currentHref = '#' + currentHref;
+          // Strip any method "anchor" that may follow the serviceId, and
+          // prepend '#' to match href.
+          currentHref = '#' + currentHref.replace(/[#\.].+$/, '');
 
           if (currentHref === href) {
             elem.addClass('current');

--- a/site/src/app/service/service.controller.js
+++ b/site/src/app/service/service.controller.js
@@ -25,11 +25,16 @@
     }
 
     function watchMethod() {
-      return DeeplinkService.watch($scope, getMethod);
+      return DeeplinkService.watch($scope, getAnchor);
     }
 
-    function getMethod() {
-      return $state.params && $state.params.method;
+    function getAnchor() {
+      var serviceId = $state.params && $state.params.serviceId;
+      // Only return anchor if serviceId is for a method in the service, not the
+      // service itself). If so, the method's id will be an anchor in the page.
+      if (serviceId !== service.id) {
+        return serviceId;
+      }
     }
 
     function sortMethods(a, b) {

--- a/site/src/app/service/service.html
+++ b/site/src/app/service/service.html
@@ -30,8 +30,8 @@
   </article>
   <article ng-repeat="method in service.methods">
     <h2 ng-if="method.isConstructor">{{::method.name}}</h2>
-    <h3 id="{{::method.name}}" ng-if="!method.isConstructor" class="method-heading">
-      <a class="permalink" ui-sref="docs.service({ method: method.name })">
+    <h3 id="{{::method.id}}" ng-if="!method.isConstructor" class="method-heading">
+      <a class="permalink" ui-sref="docs.service({ serviceId: method.id })">
         <span>{{::method.typeSymbol}}</span>
         {{::method.name}}
       </a>
@@ -40,7 +40,7 @@
     <div ng-if="method.isConstructor" class="notice">
       Available methods:
       <span ng-repeat="method in service.methods">
-        <a ui-sref="docs.service({ method: method.name })">{{method.name}}</a>{{$last ? '' : ', '}}
+        <a ui-sref="docs.service({ serviceId: method.id })">{{method.name}}</a>{{$last ? '' : ', '}}
       </span>
     </div>
     <section ng-if="method.params.length">


### PR DESCRIPTION
This PR allows deep linking to a method using the method's `id` rather than its name, which was problematic in Ruby due to duplicate method names in the same namespace.

[Demo](http://quartzmo.github.io/gcloud-ruby/#/docs/master/gcloud)

[refs #79]

The PR depends on adding entries to `types.json` for all methods. The entries for methods should reference the `title` and `contents` values for the parent class (or other namespace). For example:

```js
  {
    "id": "gcloud",
    "title": "Gcloud",
    "contents": "gcloud.json"
  },
  {
    "id": "gcloud.new",
    "title": "Gcloud",
    "contents": "gcloud.json"
  },
  {
    "id": "gcloud#datastore",
    "title": "Gcloud",
    "contents": "gcloud.json"
  },
  ...
  {
    "id": "gcloud.datastore",
    "title": "Gcloud",
    "contents": "gcloud.json"
  },
  ...
```

This PR replaces outdated #100. 