### PR TITLE
site: revert method URLs to ?method={id}

### DIFF
--- a/site/src/app/components/custom-type/custom-type.directive.js
+++ b/site/src/app/components/custom-type/custom-type.directive.js
@@ -7,13 +7,17 @@
 
   /** @ngInject */
   function customType($state) {
-    var convertToServicePath = function(customType) {
+    var convertToServicePath = function(customType, method) {
       var stateName = 'docs.service';
       var stateParams = {
         serviceId: customType,
         version: $state.params.version
       };
       var stateOptions = { inherit: false };
+
+      if (method) {
+        stateParams.method = method;
+      }
 
       return $state.href(stateName, stateParams, stateOptions);
     };
@@ -22,11 +26,14 @@
       restrict: 'A',
       link: function (scope, elem, attrs) {
         var customType = attrs.customType;
+        var method = attrs.method;
+
         if (elem.html().length === 0) {
-          elem.html(customType); // Set path as text if no text in element
+          // Set narrowest scope as text if no text in element
+          elem.html(method ? method : customType);
         }
         elem.addClass('skip-external-link')
-          .attr('href', convertToServicePath(customType.replace('[]', '')));
+          .attr('href', convertToServicePath(customType.replace('[]', ''), method));
       }
     };
   }

--- a/site/src/app/components/side-nav-link/side-nav-link.directive.js
+++ b/site/src/app/components/side-nav-link/side-nav-link.directive.js
@@ -25,9 +25,7 @@
         }
 
         function toggleClass(currentHref) {
-          // Strip any method "anchor" that may follow the serviceId, and
-          // prepend '#' to match href.
-          currentHref = '#' + currentHref.replace(/[#\.].+$/, '');
+          currentHref = '#' + currentHref;
 
           if (currentHref === href) {
             elem.addClass('current');

--- a/site/src/app/service/service.controller.js
+++ b/site/src/app/service/service.controller.js
@@ -25,16 +25,11 @@
     }
 
     function watchMethod() {
-      return DeeplinkService.watch($scope, getAnchor);
+      return DeeplinkService.watch($scope, getMethod);
     }
 
-    function getAnchor() {
-      var serviceId = $state.params && $state.params.serviceId;
-      // Only return anchor if serviceId is for a method in the service, not the
-      // service itself). If so, the method's id will be an anchor in the page.
-      if (serviceId !== service.id) {
-        return serviceId;
-      }
+    function getMethod() {
+      return $state.params && $state.params.method;
     }
 
     function sortMethods(a, b) {

--- a/site/src/app/service/service.html
+++ b/site/src/app/service/service.html
@@ -31,7 +31,7 @@
   <article ng-repeat="method in service.methods">
     <h2 ng-if="method.isConstructor">{{::method.name}}</h2>
     <h3 id="{{::method.id}}" ng-if="!method.isConstructor" class="method-heading">
-      <a class="permalink" ui-sref="docs.service({ serviceId: method.id })">
+      <a class="permalink" ui-sref="docs.service({ method: method.id })">
         <span>{{::method.typeSymbol}}</span>
         {{::method.name}}
       </a>
@@ -40,7 +40,7 @@
     <div ng-if="method.isConstructor" class="notice">
       Available methods:
       <span ng-repeat="method in service.methods">
-        <a ui-sref="docs.service({ serviceId: method.id })">{{method.name}}</a>{{$last ? '' : ', '}}
+        <a ui-sref="docs.service({ method: method.id })">{{method.name}}</a>{{$last ? '' : ', '}}
       </span>
     </div>
     <section ng-if="method.params.length">


### PR DESCRIPTION
Like PR #109, which is partially reverts, this PR allows deep linking to a method using the method's `id` rather than its name, which was problematic in Ruby due to duplicate method names in the same namespace.

However, unlike #109, this PR preserves the `?method={id}` query param URL signature. Projects without method name conflicts, such as gcloud-node, may simply use the same value for `method.id` as for `method.name` in docs JSON. (gcloud-ruby creates `method.id` by appending `method.type` to `method.name`.)

[Demo](http://quartzmo.github.io/gcloud-ruby/#/docs/master/gcloud)

[closes #113]

/cc @blowmage @stephenplusplus
