### PR TITLE
docs: overload pre tag to apply syntax highlighting

### DIFF
--- a/site/src/app/components/markdown/markdown-highlight.directive.js
+++ b/site/src/app/components/markdown/markdown-highlight.directive.js
@@ -1,0 +1,33 @@
+(function() {
+  'use strict';
+
+  angular
+    .module('gcloud')
+    .directive('pre', markdownHighlight);
+
+  /** @ngInject */
+  function markdownHighlight(hljs) {
+    return {
+      restrict: 'E',
+      link: function(scope, elem) {
+        if (elem.hasClass('skip-highlight')) {
+          return;
+        }
+
+        var codeBlocks = elem.children('code');
+
+        if (!codeBlocks.length) {
+          return;
+        }
+
+        var unwatch = scope.$watch(highlight);
+
+        function highlight() {
+          angular.forEach(codeBlocks, hljs.highlightBlock, hljs);
+          unwatch();
+        }
+      }
+    };
+  }
+
+}());

--- a/site/src/app/components/markdown/markdown.directive.js
+++ b/site/src/app/components/markdown/markdown.directive.js
@@ -1,4 +1,3 @@
-/* global hljs: true */
 (function() {
   'use strict';
 
@@ -7,20 +6,20 @@
     .directive('markdown', markdown);
 
   /** @ngInject */
-  function markdown(markdownConverter) {
+  function markdown($compile, markdownConverter) {
     return {
       restrict: 'E',
       link: function(scope, elem) {
-        var html = markdownConverter.makeHtml(elem.text());
-        var node = angular.element(html);
+        var unwatch = scope.$on('$includeContentLoaded', compile);
 
-        [].slice.call(node.find('code')).filter(function(code) {
-          return code.parentNode.tagName.toLowerCase() === 'pre';
-        }).forEach(function(code) {
-          hljs.highlightBlock(code);
-        });
+        function compile() {
+          var html = markdownConverter.makeHtml(elem.text());
+          var node = angular.element(html);
 
-        elem.html('').append(node);
+          elem.html('').append(node);
+          $compile(elem.contents())(scope);
+          unwatch();
+        }
       }
     };
   }

--- a/site/src/app/docs/docs.service.js
+++ b/site/src/app/docs/docs.service.js
@@ -1,4 +1,3 @@
-/* global hljs:true */
 (function() {
   'use strict';
 
@@ -55,8 +54,7 @@
       var code, caption;
 
       if (example.code) {
-        code = hljs.highlight(manifest.markdown, example.code);
-        code = $sce.trustAsHtml(code.value);
+        code = $sce.trustAsHtml(example.code);
       }
 
       if (example.caption) {

--- a/site/src/app/index.constants.js
+++ b/site/src/app/index.constants.js
@@ -1,8 +1,10 @@
+/* global hljs: true */
 (function() {
   'use strict';
 
   angular
     .module('gcloud')
+    .constant('hljs', hljs)
     .constant('langs', [{
       friendly: 'Java',
       key: 'java'


### PR DESCRIPTION
Closes #116 

This PR will search for code snippets via `<pre><code></code></pre>` tags and auto highlight them. It's possible to bypass this by adding a class of `skip-highlight` to the `<pre>` tag. If the `<pre>` does **not** contain a `<code>` tag, it will **not** apply highlighting.

/cc @quartzmo @stephenplusplus 