### PR TITLE
docs: inherit version when omitted

### DIFF
--- a/site/src/app/docs/docs.route.js
+++ b/site/src/app/docs/docs.route.js
@@ -83,7 +83,7 @@
         params[0] = latestVersion;
       } else {
         // otherwise let's assume the version was omitted entirely
-        params.unshift(latestVersion);
+        params.unshift($injector.get('$stateParams').version || latestVersion);
       }
 
       return docsBaseUrl + params.join('/');


### PR DESCRIPTION
Relates to https://github.com/GoogleCloudPlatform/gcloud-ruby/pull/596

When transitioning from a route with a `version` param supplied to one without, the routing logic will redirect the user to the latest version. This change will attempt to resolve the route with the most previously viewed version and if unavailable will then redirect to the latest version.

/cc @blowmage @quartzmo 