### PR TITLE
docs: limit scope of highlight languages

### DIFF
--- a/site/src/app/service/service.html
+++ b/site/src/app/service/service.html
@@ -70,7 +70,7 @@
       <div ng-repeat="example in method.examples">
         <div ng-if="example.caption" bind-html-compile="example.caption"></div>
         <div ng-if="example.code" class="code-block">
-          <pre><code class="hljs" bind-html-compile="example.code"></code></pre>
+          <pre><code class="hljs {{::markdown}}" bind-html-compile="example.code"></code></pre>
         </div>
       </div>
     </section>


### PR DESCRIPTION
Looks like `hljs` is misinterpreting some of our snippets ([`startQuery` as CSS](https://googlecloudplatform.github.io/gcloud-node/#/docs/v0.29.0/bigquery?method=startQuery)).

This will explicitly set all code examples on service pages to the code flavor defined in the <kbd>manifest.json</kbd>