### PR TITLE
site: add service-level examples

### DIFF
--- a/site/src/app/service/service.html
+++ b/site/src/app/service/service.html
@@ -27,6 +27,15 @@
         </li>
       </ul>
     </section>
+    <section ng-if="service.examples.length">
+      <h4>Example</h4>
+      <div ng-repeat="example in service.examples">
+        <div ng-if="example.caption" bind-html-compile="example.caption"></div>
+        <div ng-if="example.code" class="code-block">
+          <pre><code class="hljs {{::markdown}}" bind-html-compile="example.code"></code></pre>
+        </div>
+      </div>
+    </section>
   </article>
   <article ng-repeat="method in service.methods">
     <h2 ng-if="method.isConstructor">{{::method.name}}</h2>


### PR DESCRIPTION
I just noticed that gcloud-ruby's dozens of class-level examples are not displayed in the site, although they have been present in the docs JSON. This PR adds a conditional section exposing them.

[Demo](https://quartzmo.github.io/gcloud-ruby/#/docs/master/gcloud/datastore/dataset/lookupresults)

Before (missing examples):

![without_examples](https://cloud.githubusercontent.com/assets/205445/14871168/38ccc706-0c9d-11e6-8eee-bc0303831cac.png)

After:

![with_examples](https://cloud.githubusercontent.com/assets/205445/14871182/512db850-0c9d-11e6-9285-c7c5b3a63e3f.png)

/cc @stephenplusplus @blowmage @jgeewax




