### PR TITLE
site: add support for configurable title characters

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -9,6 +9,7 @@
   * [`lang`][lang-key]
   * [`friendlyLang`][friendlylang-key]
   * [`markdown`][markdown-key]
+  * [`titleDelimiter`][delimiter-key]
   * [`versions`][versions-key]
   * [`content`][content-key]
   * [`home`][home-key]
@@ -126,6 +127,16 @@ The Angular app currently leverages a code highlighting library called [highligh
 ```js
 {
   "markdown": "javascript"
+}
+```
+
+##### `titleDelimiter` key
+
+*This key is completely optional*. Used for joining title strings together, if omitted the default value is `" » "`.
+
+```js
+{
+  "titleDelimiter": " » "
 }
 ```
 
@@ -274,7 +285,7 @@ The types section lists all the available data types for the application. All ty
 
 The `id` key will be used to map content from urls - `/docs/v0.28.0/storage/bucket` will map to `"id": "storage/bucket"`
 
-The `title` key will be used to create a title on the service page.
+The `title` key will be used to create a title on the service page. You can provide either a string or an array of strings that will be joined by a special character specified in the <kbd>manifest.json</kbd> via [`titleDelimiter`][delimiter-key].
 
 ```js
 {
@@ -283,7 +294,7 @@ The `title` key will be used to create a title on the service page.
     "id": "storage",
     "contents": "storage/index.json"
   }, {
-    "title": "Storage » Bucket",
+    "title": ["Storage", "Bucket"],
     "id": "storage/bucket",
     "contents": "storage/bucket.json"
   }]
@@ -496,6 +507,7 @@ Please refer to gcloud-node's [`gh-pages` branch][gcloud-node-ghpages] for an ex
 [lang-key]: #lang-key
 [friendlylang-key]: #friendlylang-key
 [markdown-key]: #markdown-key
+[delimiter-key]: #titledelimiter-key
 [versions-key]: #versions-key
 [content-key]: #content-key
 [home-key]: #home-key

--- a/site/src/app/components/page-header/page-header.directive.js
+++ b/site/src/app/components/page-header/page-header.directive.js
@@ -17,6 +17,10 @@
       },
       link: function(scope) {
         scope.title = scope.title || manifest.friendlyLang;
+
+        if (angular.isArray(scope.title)) {
+          scope.title = scope.title.join(manifest.titleDelimiter || ' » ');
+        }
       }
     };
   }


### PR DESCRIPTION
Closes #133 

This adds an (optional) field to the <kbd>manifest.json</kbd> called `titleDelimiter`. If this is set and a page title is found in the form of an Array, the Angular app will join said array with the value of `titleDelimiter`.

---

### Example

<kbd>manifest.json</kbd>

```js
{
  "titleDelimiter": "::"
}
```

<kbd>types.json</kbd>

```js
[{
  "id": "storage/bucket",
  "title": ["Storage", "Bucket"],
  "contents": "storage/bucket.json"
}]
```

Yields `Storage::Bucket` for the title of `/docs/{version}/storage/bucket`.

/cc @jgeewax @daspecster