### PR TITLE
add margin between examples with no captions

### DIFF
--- a/site/src/app/service/service.html
+++ b/site/src/app/service/service.html
@@ -31,7 +31,7 @@
       <h4>Example</h4>
       <div ng-repeat="example in service.examples">
         <div ng-if="example.caption" bind-html-compile="example.caption"></div>
-        <div ng-if="example.code" class="code-block">
+        <div ng-if="example.code" class="code-block" ng-class="{'margin-top': !example.caption && $index > 0}>
           <pre><code class="hljs {{::markdown}}" bind-html-compile="example.code"></code></pre>
         </div>
       </div>
@@ -77,7 +77,7 @@
       <h4>Example</h4>
       <div ng-repeat="example in method.examples">
         <div ng-if="example.caption" bind-html-compile="example.caption"></div>
-        <div ng-if="example.code" class="code-block">
+        <div ng-if="example.code" class="code-block" ng-class="{'margin-top': !example.caption && $index > 0}">
           <pre><code class="hljs {{::markdown}}" bind-html-compile="example.code"></code></pre>
         </div>
       </div>

--- a/site/src/app/styles/_main.scss
+++ b/site/src/app/styles/_main.scss
@@ -255,6 +255,10 @@ ul {
     margin: 10px;
 }
 
+.margin-top {
+   margin-top: 10px;
+}
+
 .margin-left {
     margin-left: 10px;
 }


### PR DESCRIPTION
If an example has no caption it merges into the previous example making it look as if there is one big example.

This PR adds a margin between examples for these instances.

I added a new class `margin-top` which follows the standard for other utility classes. What do guys you think, does this seem useful?

<img width="547" alt="screen shot 2016-06-13 at 12 08 16 pm" src="https://cloud.githubusercontent.com/assets/2079879/16014619/f9d7ba78-315f-11e6-900f-49f0d9b82f4b.png">
