### PR TITLE
Add margin between class description and methods

### DIFF
--- a/site/src/app/service/service.html
+++ b/site/src/app/service/service.html
@@ -16,7 +16,7 @@
       ng-include="docs.overviewFileUrl"></article>
     <hr />
   </div>
-  <article ng-if="service.description || service.resources.length">
+  <article ng-if="service.description || service.resources.length" class="description">
     <h3>{{::service.name}} Overview</h3>
     <div ng-if="service.description" bind-html-compile="service.description"></div>
     <section ng-if="service.resources.length">

--- a/site/src/app/styles/_main.scss
+++ b/site/src/app/styles/_main.scss
@@ -887,6 +887,10 @@ ul {
     position: relative;
 }
 
+.description {
+    margin-bottom: 2em;
+}
+
 .notice {
   background-color: #e5ecf9;
   padding: 8px;


### PR DESCRIPTION
When examples are present on the top level of a service, the example container runs right up against the available methods container, as shown in this screenshot:

![screen shot 2016-07-26 at 4 45 03 pm](https://cloud.githubusercontent.com/assets/89034/17154745/55a86cfa-5350-11e6-9096-c5b9529dff50.png)

This change adds a class of `description` to the `article` tag in service.html that contains the description of the service, and sets the `margin-bottom` of `.description` to `2em`, resulting in the following:

![screen shot 2016-07-26 at 4 46 20 pm](https://cloud.githubusercontent.com/assets/89034/17154824/9e065106-5350-11e6-89c2-2e88b207876f.png)
