### PR TITLE
Fix for 404 when not using default service of gcloud

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -8,6 +8,8 @@
 * [Manifest][manifest]
   * [`lang`][lang-key]
   * [`friendlyLang`][friendlylang-key]
+  * [`libraryTitle`][librarytitle-key]
+  * [`defaultService`][defaultservice-key]
   * [`markdown`][markdown-key]
   * [`titleDelimiter`][delimiter-key]
   * [`versions`][versions-key]
@@ -526,6 +528,8 @@ Please refer to gcloud-node's [`gh-pages` branch][gcloud-node-ghpages] for an ex
 [manifest]: #manifest
 [lang-key]: #lang-key
 [friendlylang-key]: #friendlylang-key
+[librarytitle-key]: #librarytitle-key
+[defaultservice-key]: #defaultservice-key
 [markdown-key]: #markdown-key
 [delimiter-key]: #titledelimiter-key
 [versions-key]: #versions-key

--- a/site/src/app/index.run.js
+++ b/site/src/app/index.run.js
@@ -15,7 +15,7 @@
 
       $state.go('docs.service', {
         version: $state.params.version,
-        serviceId: 'gcloud'
+        serviceId: manifest.defaultService || 'gcloud'
       });
     });
   }


### PR DESCRIPTION
@jdpedrie noticed an issue where 404s were causing the docs site to hang up when not using `gcloud` as the default service. This should fix it :)