### PR TITLE
site: modularization support

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -17,6 +17,9 @@
   * [`home`][home-key]
   * [`package`][package-key]
   * [`methodTypeSymbols`][methodtypesymbols-key]
+  * [`moduleName`][modulename-key]
+  * [`defaultModule`][defaultmodule-key]
+  * [`modules`][modules-key]
 * [Table of Contents][toc]
   * [`overview`][overview-key]
   * [`guides`][guides-key]
@@ -37,6 +40,7 @@
   * [Landing Page][landing-page]
   * [Overview Section][overview-section]
   * [Custom Page Headers][custom-page-headers]
+* [Modular Docs][modular-docs]
 * [Deploying][deploying]
 
 ## Installation
@@ -229,6 +233,49 @@ This optional list allows you to map language-specific method type names (such a
     {
       "type": "instance",
       "symbol": "#"
+    }
+  ]
+}
+```
+
+##### `moduleName`
+
+The name of your module, this is used to create links to GitHub/Stackoverflow/etc.
+
+```js
+{
+  "moduleName": "gcloud-node"
+}
+```
+
+##### `defaultModule`
+
+When using [modular docs][modular-docs], use this key to set the default module. The app will direct the user to this module in the event of an error and/or when the module has been omitted altogether.
+
+The value should be the `id` of a module listed within the [`modules`][modules-key] array.
+
+```js
+{
+  "defaultModule": "google-cloud"
+}
+```
+
+##### `modules`
+
+This field is only needed when using modular docs. When present it should contain a list of separate modules you wish to display docs for.
+
+```js
+{
+  "modules": [
+    {
+      "id": "google-cloud", // id used for routing
+      "name": "google-cloud", // name used for display purposes
+      "defaultService": "storage", // default service page
+      "versions": [ // available versions of the module
+        "v0.29.0",
+        "v0.10.0",
+        "master"
+      ]
     }
   ]
 }
@@ -510,6 +557,29 @@ See [gcloud-node docs][gcloud-node-docs] for a working demo. The contents of the
 
 See a living example of gcloud-node's overview template [here][gcloud-node-overview].
 
+## Modular Docs
+
+If your library uses a modular approach (a separate installable package per service), you can optionally leverage the modular docs. To do this you must first make sure that your [manifest][manifest] contains the [`modules`][modules-key] and [`defaultModule`][defaultmodule-key] fields.
+
+After which, you must create a folder within your content directory for each package. Each package should map to a module listed within your manifest. Here is an example of what your content folder should resemble
+
+```sh
+json
+ ├─── bigquery #standalone package
+ |     └─── master
+ |           ├─── toc.json # table of contents for this version
+ |           ├─── types.json # list of custom types for this version
+ |           └─── index.json # # one file per class/module/etc.
+ |
+ └─── google-cloud # bundled package
+       └─── v0.28.0
+             ├─── toc.json # table of contents for this version
+             ├─── types.json # list of custom types for this version
+             └─── storage # one folder per service
+                   ├─── index.json 
+                   └─── bucket.json
+```
+
 ## Deploying
 
 Integrating the shared docs app is fairly painless. There is a [shell script][gcloud-common-deploy] that will push the updated site code to your `gh-pages` after a successful merge. To enable this, simply append a command to push to your repo to the script.
@@ -539,6 +609,9 @@ Please refer to gcloud-node's [`gh-pages` branch][gcloud-node-ghpages] for an ex
 [guides-key]: #guides-key
 [services-key]: #services-key
 [package-key]: #package-key
+[modulename-key]: #modulename-key
+[defaultmodule-key]: #defaultmodule-key
+[modules-key]: #modules-key
 [json-schema]: #json-docs-schema
 [id-key]: #id-key
 [description-keys]: #description-and-caption-keys
@@ -558,6 +631,7 @@ Please refer to gcloud-node's [`gh-pages` branch][gcloud-node-ghpages] for an ex
 [types]: #types
 [types-key]: #types-key
 [methodtypesymbols-key]: #methodtypesymbols-key
+[modular-docs]: #modular-docs
 
 [nodejs]: https://nodejs.org/en/
 [hljs]: https://highlightjs.org/

--- a/site/schemas/manifest.schema.json
+++ b/site/schemas/manifest.schema.json
@@ -22,6 +22,16 @@
       "type": "string",
       "description": "Custom service type to load by default."
     },
+    "moduleName": {
+      "id": "moduleName",
+      "type": "string",
+      "description": "Name of the module used to link to Github repo"
+    },
+    "defaultModule": {
+      "id": "defaultModule",
+      "type": "string",
+      "description": "id of default module when using modular docs"
+    },
     "markdown": {
       "id": "markdown",
       "type": "string",
@@ -93,15 +103,68 @@
           "symbol"
         ]
       }
+    },
+    "modules": {
+      "id": "modules",
+      "type": "array",
+      "description": "List of modules and their versions",
+      "items": {
+        "id": "module",
+        "type": "object",
+        "description": "Information for individual module",
+        "properties": {
+          "id": {
+            "id": "id",
+            "type": "string",
+            "description": "id used within route parameter"
+          },
+          "name": {
+            "id": "name",
+            "type": "string",
+            "description": "Friendly name used for module switching dropdown"
+          },
+          "defaultService": {
+            "id": "defaultService",
+            "type": "string",
+            "description": "The id of the default service for the module"
+          },
+          "versions": {
+            "id": "versions",
+            "type": "array",
+            "description": "An array of all available versions for this module",
+            "items": {
+              "id": "version",
+              "type": "string",
+              "description": "The semver version string"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "defaultService",
+          "versions"
+        ]
+      }
     }
   },
   "required": [
     "lang",
     "friendlyLang",
+    "moduleName",
     "markdown",
-    "versions",
     "content",
     "home",
     "package"
-  ]
+  ],
+  "oneOf": [{
+    "required": [
+      "versions"
+    ]
+  }, {
+    "required": [
+      "defaultModule",
+      "modules"
+    ]
+  }]
 }

--- a/site/schemas/service.schema.json
+++ b/site/schemas/service.schema.json
@@ -17,6 +17,11 @@
       "type": "string",
       "description": "Brief overview of the service"
     },
+    "overview": {
+      "id": "overview",
+      "type": "string",
+      "description": "Replacement for overview.html file"
+    },
     "resources": {
       "id": "resources",
       "type": "array",

--- a/site/src/app/components/custom-type/custom-type.directive.js
+++ b/site/src/app/components/custom-type/custom-type.directive.js
@@ -11,7 +11,8 @@
       var stateName = 'docs.service';
       var stateParams = {
         serviceId: customType,
-        version: $state.params.version
+        version: $state.params.version,
+        package: $state.params.package || ''
       };
       var stateOptions = { inherit: false };
 

--- a/site/src/app/components/custom-type/custom-type.directive.js
+++ b/site/src/app/components/custom-type/custom-type.directive.js
@@ -6,21 +6,39 @@
     .directive('customType', customType);
 
   /** @ngInject */
-  function customType($state) {
-    var convertToServicePath = function(customType, method) {
-      var stateName = 'docs.service';
-      var stateParams = {
-        serviceId: customType,
-        version: $state.params.version,
-        module: $state.params.module || ''
-      };
-      var stateOptions = { inherit: false };
+  function customType($state, util) {
+    var convertToServicePath = function(scope, customType, method) {
+      var isInclusive = !!util.findWhere(scope.docs.types, {
+        id: customType
+      });
 
-      if (method) {
-        stateParams.method = method;
+      var href = [
+        '#',
+        'docs'
+      ];
+
+      if (isInclusive) {
+        var params = [
+          $state.params.version,
+          customType
+        ];
+
+        if ($state.params.module) {
+          params.unshift($state.params.module);
+        }
+
+        href = href.concat(params);
+      } else {
+        href.push(customType);
       }
 
-      return $state.href(stateName, stateParams, stateOptions);
+      href = href.join('/');
+
+      if (method) {
+        href += '?method=' + method;
+      }
+
+      return href;
     };
 
     return {
@@ -33,8 +51,9 @@
           // Set narrowest scope as text if no text in element
           elem.html(method ? method : customType);
         }
-        elem.addClass('skip-external-link')
-          .attr('href', convertToServicePath(customType.replace('[]', ''), method));
+
+        var href = convertToServicePath(scope, customType.replace('[]', ''), method);
+        elem.addClass('skip-external-link').attr('href', href);
       }
     };
   }

--- a/site/src/app/components/custom-type/custom-type.directive.js
+++ b/site/src/app/components/custom-type/custom-type.directive.js
@@ -12,7 +12,7 @@
       var stateParams = {
         serviceId: customType,
         version: $state.params.version,
-        package: $state.params.package || ''
+        module: $state.params.module || ''
       };
       var stateOptions = { inherit: false };
 

--- a/site/src/app/components/dropdown/dropdown.directive.js
+++ b/site/src/app/components/dropdown/dropdown.directive.js
@@ -1,0 +1,30 @@
+(function() {
+  'use strict';
+
+  angular
+    .module('gcloud')
+    .directive('dropdown', dropdown);
+
+  /** @ngInject */
+  function dropdown() {
+    return {
+      restrict: 'E',
+      replace: true,
+      templateUrl: 'app/components/dropdown/dropdown.html',
+      transclude: true,
+      scope: {
+        selected: '='
+      },
+      controller: DropdownCtrl,
+      controllerAs: 'dropdown',
+      bindToController: true
+    };
+  }
+
+  /** @ngInject */
+  function DropdownCtrl() {
+    var dropdown = this;
+
+    dropdown.isOpen = false;
+  }
+}());

--- a/site/src/app/components/dropdown/dropdown.html
+++ b/site/src/app/components/dropdown/dropdown.html
@@ -1,0 +1,8 @@
+<nav class="dropdown" ng-class="{ open: dropdown.isOpen }">
+  <div class="dropdown-current" ng-click="dropdown.isOpen = !dropdown.isOpen">
+    {{dropdown.selected}}
+  </div>
+  <div ng-click="dropdown.isOpen = false">
+    <ul class="menu" ng-transclude></ul>
+  </div>
+</nav>

--- a/site/src/app/components/language-switcher/language-switcher.directive.js
+++ b/site/src/app/components/language-switcher/language-switcher.directive.js
@@ -6,20 +6,14 @@
     .directive('languageSwitcher', languageSwitcher);
 
   /** @ngInject */
-  function languageSwitcher() {
+  function languageSwitcher(langs, manifest) {
     return {
       restrict: 'A',
       templateUrl: 'app/components/language-switcher/language-switcher.html',
-      controller: LanguageSwitcherCtrl,
-      controllerAs: 'switcher',
-      bindToController: true
+      link: function(scope) {
+        scope.langs = langs;
+        scope.modules = manifest.modules;
+      }
     };
-  }
-
-  /** @ngInject */
-  function LanguageSwitcherCtrl(langs) {
-    var switcher = this;
-
-    switcher.langs = langs;
   }
 }());

--- a/site/src/app/components/language-switcher/language-switcher.html
+++ b/site/src/app/components/language-switcher/language-switcher.html
@@ -30,25 +30,25 @@
     <h4 class="list-item--heading">External Resources</h4>
   </li>
   <li class="invisible-lg">
-    <a ng-href="https://github.com/GoogleCloudPlatform/gcloud-{{::lang}}" title="google-cloud on Github" class="skip-external-link">
+    <a ng-href="https://github.com/GoogleCloudPlatform/{{::moduleName}}" title="google-cloud on Github" class="skip-external-link">
       <img src="assets/images/icon-link-github.svg" alt="GitHub icon" class="menu-icon" />
       GitHub
     </a>
   </li>
   <li class="invisible-lg">
-    <a ng-href="https://github.com/GoogleCloudPlatform/gcloud-{{::lang}}/issues" title="google-cloud issues on Github" class="skip-external-link">
+    <a ng-href="https://github.com/GoogleCloudPlatform/{{::moduleName}}/issues" title="google-cloud issues on Github" class="skip-external-link">
       <img src="assets/images/icon-link-github.svg" alt="GitHub icon" class="menu-icon" />
       Issues
     </a>
   </li>
   <li class="invisible-lg">
-    <a ng-href="http://stackoverflow.com/questions/tagged/gcloud-{{::lang}}" title="google-cloud on StackOverflow" class="skip-external-link">
+    <a ng-href="http://stackoverflow.com/questions/tagged/{{::moduleName}}" title="google-cloud on StackOverflow" class="skip-external-link">
       <img src="assets/images/icon-link-stackoverflow.svg" alt="StackOverflow icon" class="menu-icon" />
       StackOverflow
     </a>
   </li>
   <li class="invisible-lg">
-    <a ng-href="{{::package.href}}" ng-attr-title="gcloud on {{::package.title}}" class="skip-external-link">
+    <a ng-href="{{::package.href}}" ng-attr-title="Google Cloud on {{::package.title}}" class="skip-external-link">
       <img src="assets/images/icon-link-package-manager.svg" ng-attr-alt="{{::package.title}} icon" class="menu-icon" />
       {{::package.title}}
     </a>

--- a/site/src/app/components/language-switcher/language-switcher.html
+++ b/site/src/app/components/language-switcher/language-switcher.html
@@ -1,68 +1,71 @@
-<nav class="main-nav" ng-class="{ open: showNavDropdown }">
-  <div class="nav-current" ng-click="showNavDropdown = !showNavDropdown">
-    {{::friendlyLang}}
-  </div>
-  <div ng-click="showNavDropdown = false">
-    <ul class="menu">
-      <li ng-if="docs.guides.length" class="invisible-lg">
-        <h4 class="list-item--heading">Getting Started</h4>
-      </li>
-      <li ng-repeat="page in docs.guides" class="invisible-lg">
-        <a side-nav-link="/guides/{{page.id}}">{{page.title}}</a>
-      </li>
-      <li ng-if="docs.services.length" class="invisible-lg">
-        <h4 class="list-item--heading">API</h4>
-      </li>
-      <li ng-repeat="service in docs.services" class="menu--extra-links-item invisible-lg">
-        <a side-nav-link="/{{service.type}}">{{service.title || service.type}}</a>
-        <ul class="sub-sections" ng-if="service.nav">
-          <li ng-repeat="page in service.nav">
-            <a side-nav-link="/{{page.type}}">{{page.title || page.type}}</a>
-          </li>
-        </ul>
-      </li>
-      <li class="invisible-lg">
-        <h4 class="list-item--heading">External Resources</h4>
-      </li>
-      <li class="invisible-lg">
-        <a ng-href="https://github.com/GoogleCloudPlatform/gcloud-{{::lang}}" title="gcloud on Github" class="skip-external-link">
-          <img src="assets/images/icon-link-github.svg" alt="GitHub icon" class="menu-icon" />
-          GitHub
-        </a>
-      </li>
-      <li class="invisible-lg">
-        <a ng-href="https://github.com/GoogleCloudPlatform/gcloud-{{::lang}}/issues" title="gcloud issues on Github" class="skip-external-link">
-          <img src="assets/images/icon-link-github.svg" alt="GitHub icon" class="menu-icon" />
-          Issues
-        </a>
-      </li>
-      <li class="invisible-lg">
-        <a ng-href="http://stackoverflow.com/questions/tagged/gcloud-{{::lang}}" title="gcloud on StackOverflow" class="skip-external-link">
-          <img src="assets/images/icon-link-stackoverflow.svg" alt="StackOverflow icon" class="menu-icon" />
-          StackOverflow
-        </a>
-      </li>
-      <li class="invisible-lg">
-        <a ng-href="{{::package.href}}" ng-attr-title="gcloud on {{::package.title}}" class="skip-external-link">
-          <img src="assets/images/icon-link-package-manager.svg" ng-attr-alt="{{::package.title}} icon" class="menu-icon" />
-          {{::package.title}}
-        </a>
-      </li>
-      <li class="invisible-lg">
-        <h4 class="list-item--heading">gcloud Libraries</h4>
-      </li>
-      <li ng-repeat="lang in switcher.langs">
-        <a
-          ng-href="https://googlecloudplatform.github.io/{{::lang.repo}}"
-          ng-attr-title="{{::lang.repo}}"
-          class="skip-external-link">
-          <img
-            ng-src="assets/images/icon-lang-{{::lang.key}}.svg"
-            ng-attr-alt="gcloud-{{::lang.key}}"
-            class="menu-icon">
-          {{::lang.friendly}}
-        </a>
+<dropdown selected="friendlyLang" class="language-switcher">
+  <li ng-if="docs.guides.length" class="invisible-lg">
+    <h4 class="list-item--heading">Getting Started</h4>
+  </li>
+  <li ng-repeat="page in docs.guides" class="invisible-lg">
+    <a side-nav-link="/guides/{{page.id}}">{{page.title}}</a>
+  </li>
+  <li ng-if="docs.services.length" class="invisible-lg">
+    <h4 class="list-item--heading">API</h4>
+  </li>
+  <li ng-repeat="service in docs.services" class="menu--extra-links-item invisible-lg">
+    <a side-nav-link="/{{service.type}}">{{service.title || service.type}}</a>
+    <ul class="sub-sections" ng-if="service.nav">
+      <li ng-repeat="page in service.nav">
+        <a side-nav-link="/{{page.type}}">{{page.title || page.type}}</a>
       </li>
     </ul>
-  </div>
-</nav>
+  </li>
+  <li class="invisible-lg">
+    <h4 class="list-item--heading">Modules</h4>
+  </li>
+  <li class="invisible-lg" ng-repeat="module in modules">
+    <a
+      ui-sref="docs.service({ module: module.id, version: module.versions[0], serviceId: module.defaultService })"
+      ng-attr-title="{{::module.name}}">
+        {{::module.name}}
+    </a>
+  </li>
+  <li class="invisible-lg">
+    <h4 class="list-item--heading">External Resources</h4>
+  </li>
+  <li class="invisible-lg">
+    <a ng-href="https://github.com/GoogleCloudPlatform/gcloud-{{::lang}}" title="google-cloud on Github" class="skip-external-link">
+      <img src="assets/images/icon-link-github.svg" alt="GitHub icon" class="menu-icon" />
+      GitHub
+    </a>
+  </li>
+  <li class="invisible-lg">
+    <a ng-href="https://github.com/GoogleCloudPlatform/gcloud-{{::lang}}/issues" title="google-cloud issues on Github" class="skip-external-link">
+      <img src="assets/images/icon-link-github.svg" alt="GitHub icon" class="menu-icon" />
+      Issues
+    </a>
+  </li>
+  <li class="invisible-lg">
+    <a ng-href="http://stackoverflow.com/questions/tagged/gcloud-{{::lang}}" title="google-cloud on StackOverflow" class="skip-external-link">
+      <img src="assets/images/icon-link-stackoverflow.svg" alt="StackOverflow icon" class="menu-icon" />
+      StackOverflow
+    </a>
+  </li>
+  <li class="invisible-lg">
+    <a ng-href="{{::package.href}}" ng-attr-title="gcloud on {{::package.title}}" class="skip-external-link">
+      <img src="assets/images/icon-link-package-manager.svg" ng-attr-alt="{{::package.title}} icon" class="menu-icon" />
+      {{::package.title}}
+    </a>
+  </li>
+  <li class="invisible-lg">
+    <h4 class="list-item--heading">Google Cloud Platform Libraries</h4>
+  </li>
+  <li ng-repeat="lang in langs">
+    <a
+      ng-href="https://googlecloudplatform.github.io/{{::lang.repo}}"
+      ng-attr-title="{{::lang.repo}}"
+      class="skip-external-link">
+      <img
+        ng-src="assets/images/icon-lang-{{::lang.key}}.svg"
+        ng-attr-alt="google-cloud-{{::lang.key}}"
+        class="menu-icon">
+      {{::lang.friendly}}
+    </a>
+  </li>
+</dropdown>

--- a/site/src/app/components/module-switcher/module-switcher.directive.js
+++ b/site/src/app/components/module-switcher/module-switcher.directive.js
@@ -1,0 +1,26 @@
+(function() {
+  'use strict';
+
+  angular
+    .module('gcloud')
+    .directive('moduleSwitcher', moduleSwitcher);
+
+  /** @ngInject */
+  function moduleSwitcher($stateParams, manifest, util) {
+    return {
+      restrict: 'A',
+      templateUrl: 'app/components/module-switcher/module-switcher.html',
+      link: function(scope) {
+        scope.modules = manifest.modules;
+
+        scope.$watch($stateParams, function() {
+          var module = util.findWhere(manifest.modules, {
+            id: $stateParams.module
+          });
+
+          scope.selected = module.name;
+        });
+      }
+    };
+  }
+}());

--- a/site/src/app/components/module-switcher/module-switcher.html
+++ b/site/src/app/components/module-switcher/module-switcher.html
@@ -1,0 +1,10 @@
+<dropdown selected="selected" class="module-switcher">
+  <li ng-repeat="module in modules">
+    <a
+      ui-sref="docs.service({ module: module.id, version: module.versions[0], serviceId: module.defaultService })"
+      ng-attr-title="{{::module.name}}">
+        <span class="module-name">{{::module.name}}</span>
+        <span class="module-version">latest: {{::module.versions[0]}}</span>
+      </a>
+  </li>
+</dropdown>

--- a/site/src/app/components/side-nav-link/side-nav-link.directive.js
+++ b/site/src/app/components/side-nav-link/side-nav-link.directive.js
@@ -7,15 +7,16 @@
 
   /** @ngInject */
   function sideNavLink($location, $state, $interpolate) {
-    var url = $interpolate('#/docs/{{version}}{{href}}');
+    var url = $interpolate('#/docs/{{package}}/{{version}}{{href}}');
 
     return {
       restrict: 'A',
       link: function(scope, elem, attrs) {
         var href = url({
+          package: $state.params.package || '',
           version: $state.params.version,
           href: attrs.sideNavLink
-        });
+        }).replace('//', '/');
 
         elem.attr('href', href);
         scope.$watch(getPath, toggleClass);

--- a/site/src/app/components/side-nav-link/side-nav-link.directive.js
+++ b/site/src/app/components/side-nav-link/side-nav-link.directive.js
@@ -7,13 +7,13 @@
 
   /** @ngInject */
   function sideNavLink($location, $state, $interpolate) {
-    var url = $interpolate('#/docs/{{package}}/{{version}}{{href}}');
+    var url = $interpolate('#/docs/{{module}}/{{version}}{{href}}');
 
     return {
       restrict: 'A',
       link: function(scope, elem, attrs) {
         var href = url({
-          package: $state.params.package || '',
+          module: $state.params.module || '',
           version: $state.params.version,
           href: attrs.sideNavLink
         }).replace('//', '/');

--- a/site/src/app/components/version-switcher/version-switcher.html
+++ b/site/src/app/components/version-switcher/version-switcher.html
@@ -5,7 +5,7 @@
       &nbsp;
       <select
         ng-model="docs.selectedVersion"
-        ng-options="version for version in versions"
+        ng-options="version for version in docs.versions"
         ng-change="docs.loadVersion(docs.selectedVersion)"
       ></select>
       <div ng-if="selectedVersion.name === 'master' && docs.lastBuiltDate">

--- a/site/src/app/docs/docs.controller.js
+++ b/site/src/app/docs/docs.controller.js
@@ -6,7 +6,7 @@
     .controller('DocsCtrl', DocsCtrl);
 
   /** @ngInject */
-  function DocsCtrl($state, langs, manifest, toc, lastBuiltDate, versions) {
+  function DocsCtrl($state, langs, manifest, toc, types, lastBuiltDate, versions) {
     var docs = this;
 
     docs.libraryTitle = manifest.libraryTitle || 'Google Cloud';
@@ -17,6 +17,7 @@
     docs.versions = versions;
     docs.version = $state.params.version;
     docs.overviewFileUrl = null;
+    docs.types = types;
 
     docs.selectedVersion = docs.version;
     docs.loadVersion = loadVersion;

--- a/site/src/app/docs/docs.controller.js
+++ b/site/src/app/docs/docs.controller.js
@@ -6,7 +6,7 @@
     .controller('DocsCtrl', DocsCtrl);
 
   /** @ngInject */
-  function DocsCtrl($state, langs, manifest, toc, lastBuiltDate) {
+  function DocsCtrl($state, langs, manifest, toc, lastBuiltDate, versions) {
     var docs = this;
 
     docs.libraryTitle = manifest.libraryTitle || 'gcloud';
@@ -14,6 +14,7 @@
     docs.lastBuiltDate = lastBuiltDate;
     docs.guides = toc.guides;
     docs.services = toc.services;
+    docs.versions = versions;
     docs.version = $state.params.version;
     docs.overviewFileUrl = null;
 
@@ -25,6 +26,7 @@
     if (toc.overview) {
       docs.overviewFileUrl = [
         manifest.content,
+        $state.params.package,
         $state.params.version,
         toc.overview
       ].join('/');

--- a/site/src/app/docs/docs.controller.js
+++ b/site/src/app/docs/docs.controller.js
@@ -9,7 +9,7 @@
   function DocsCtrl($state, langs, manifest, toc, lastBuiltDate, versions) {
     var docs = this;
 
-    docs.libraryTitle = manifest.libraryTitle || 'gcloud';
+    docs.libraryTitle = manifest.libraryTitle || 'Google Cloud';
     docs.langs = langs;
     docs.lastBuiltDate = lastBuiltDate;
     docs.guides = toc.guides;
@@ -26,7 +26,7 @@
     if (toc.overview) {
       docs.overviewFileUrl = [
         manifest.content,
-        $state.params.package,
+        $state.params.module,
         $state.params.version,
         toc.overview
       ].join('/');

--- a/site/src/app/docs/docs.html
+++ b/site/src/app/docs/docs.html
@@ -12,6 +12,9 @@
       <div class="col">
         <div language-switcher></div>
       </div>
+      <div class="col visible-lg" ng-if="modules">
+        <div module-switcher></div>
+      </div>
     </div>
     <div class="header--right">
       <a ng-href="https://github.com/GoogleCloudPlatform/gcloud-{{::lang}}/issues/new" class="v-btn skip-external-link">

--- a/site/src/app/docs/docs.html
+++ b/site/src/app/docs/docs.html
@@ -17,7 +17,7 @@
       </div>
     </div>
     <div class="header--right">
-      <a ng-href="https://github.com/GoogleCloudPlatform/gcloud-{{::lang}}/issues/new" class="v-btn skip-external-link">
+      <a ng-href="https://github.com/GoogleCloudPlatform/{{::moduleName}}/issues/new" class="v-btn skip-external-link">
         <img src="assets/images/icon-link-github.svg">
         Report an Issue
       </a>
@@ -51,25 +51,25 @@
     </ul>
     <ul class="external-links">
       <li>
-        <a ng-href="https://github.com/GoogleCloudPlatform/gcloud-{{::lang}}" title="gcloud on Github" class="skip-external-link">
+        <a ng-href="https://github.com/GoogleCloudPlatform/{{::moduleName}}" title="Google Cloud on Github" class="skip-external-link">
           <img src="assets/images/icon-link-github.svg" alt="GitHub icon" />
           GitHub
         </a>
       </li>
       <li>
-        <a ng-href="https://github.com/GoogleCloudPlatform/gcloud-{{::lang}}/issues" title="gcloud issues on Github" class="skip-external-link">
+        <a ng-href="https://github.com/GoogleCloudPlatform/{{::moduleName}}/issues" title="Google Cloud issues on Github" class="skip-external-link">
           <img src="assets/images/icon-link-github.svg" alt="GitHub icon" />
           Issues
         </a>
       </li>
       <li>
-        <a ng-href="http://stackoverflow.com/questions/tagged/gcloud-{{::lang}}" title="gcloud on StackOverflow" class="skip-external-link">
+        <a ng-href="http://stackoverflow.com/questions/tagged/{{::moduleName}}" title="Google Cloud on StackOverflow" class="skip-external-link">
           <img src="assets/images/icon-link-stackoverflow.svg" alt="StackOverflow icon" />
           StackOverflow
         </a>
       </li>
       <li>
-        <a ng-href="{{::package.href}}" ng-attr-title="gcloud on {{::package.title}}" class="skip-external-link">
+        <a ng-href="{{::package.href}}" ng-attr-title="Google Cloud on {{::package.title}}" class="skip-external-link">
           <img src="assets/images/icon-link-package-manager.svg" ng-attr-alt="{{::package.title}} icon" />
           {{::package.title}}
         </a>

--- a/site/src/app/docs/docs.route.js
+++ b/site/src/app/docs/docs.route.js
@@ -158,8 +158,8 @@
 
   /** @ngInject */
   function getLastBuiltDate($http, manifest) {
-    var url = 'https://api.github.com/repos/GoogleCloudPlatform/gcloud-' +
-      manifest.lang + '/commits?sha=gh-pages&per_page=1';
+    var url = 'https://api.github.com/repos/GoogleCloudPlatform/' +
+      manifest.moduleName + '/commits?sha=gh-pages&per_page=1';
 
     return $http({
       method: 'get',
@@ -176,7 +176,7 @@
   function getToc($interpolate, $http, $stateParams, manifest) {
     var tocUrl = $interpolate('{{content}}/{{module}}/{{version}}/toc.json')({
       content: manifest.content,
-      module: $stateParams.module || manifest.defaultPackage,
+      module: $stateParams.module || manifest.defaultModule,
       version: $stateParams.version
     });
 
@@ -189,7 +189,7 @@
   function getTypes($interpolate, $http, $stateParams, manifest) {
     var types = $interpolate('{{content}}/{{module}}/{{version}}/types.json')({
       content: manifest.content,
-      module: $stateParams.module || manifest.defaultPackage,
+      module: $stateParams.module || manifest.defaultModule,
       version: $stateParams.version
     });
 

--- a/site/src/app/docs/docs.route.js
+++ b/site/src/app/docs/docs.route.js
@@ -89,15 +89,15 @@
       }
 
       var params = path.replace(docsBaseUrl, '').split('/');
-      var route = docsBaseUrl;
+      var correctedParams;
 
       if (manifest.modules) {
-        route += getDefaultModuleRoute(params, manifest, $injector);
+        correctedParams = getDefaultModuleParams(params, manifest, $injector);
       } else {
-        route += getDefaultRoute(params, manifest, $injector);
+        correctedParams = getDefaultParams(params, manifest, $injector);
       }
 
-      return route;
+      return docsBaseUrl + correctedParams.join('/');
     });
   }
 
@@ -215,7 +215,7 @@
     return val ? val.toString() : null;
   }
 
-  function getDefaultModuleRoute(params, manifest, $injector) {
+  function getDefaultModuleParams(params, manifest, $injector) {
     var module = $injector.get('util').findWhere(manifest.modules, {
       id: params[0]
     });
@@ -223,13 +223,13 @@
     // it's a bad module? let's try the default module
     if (!module) {
       params.unshift(manifest.defaultModule);
-      return params.join('/');
+      return params;
     }
 
     // could be a version alias
     if (params[1] === 'latest' || params[1] === 'stable') {
       params[1] = module.versions[0];
-      return params.join('/');
+      return params;
     }
 
     var moduleId = params.shift();
@@ -237,20 +237,20 @@
 
     // maybe it's a bad version? let's try the latest
     if (!isValidVersion) {
-      return [moduleId, module.versions[0], moduleId].concat(params).join('/');
+      return [moduleId, module.versions[0], moduleId].concat(params);
     }
 
     var version = params.shift();
 
     // if it's not a bad module or version, then likely the service is bad
     // so we'll go to the default service
-    return [moduleId, version, module.defaultService].join('/');
+    return [moduleId, version, module.defaultService];
   }
 
-  function getDefaultRoute(params, manifest) {
+  function getDefaultParams(params, manifest) {
     if (params[0] === 'latest' || params[0] === 'stable') {
       params[0] = manifest.versions[0];
-      return params.join('/');
+      return params;
     }
 
     var isValidVersion = manifest.versions.indexOf(params[0]) > -1;
@@ -258,13 +258,13 @@
     // could be a bad version number..
     if (!isValidVersion) {
       params.unshift(manifest.versions[0]);
-      return params.join('/');
+      return params;
     }
 
     var version = params.shift();
 
     // not a bad version number..? Then perhaps a bad service
-    return [version, manifest.defaultService || 'gcloud'].join('/');
+    return [version, manifest.defaultService || 'gcloud'];
   }
 
 }());

--- a/site/src/app/docs/docs.service.js
+++ b/site/src/app/docs/docs.service.js
@@ -30,6 +30,10 @@
         method.params = method.params.map(trustParam);
       }
 
+      if (method.overview) {
+        method.overview = $sce.trustAsHtml(method.overview);
+      }
+
       return method;
     }
 

--- a/site/src/app/guide/guide.controller.js
+++ b/site/src/app/guide/guide.controller.js
@@ -34,8 +34,9 @@
         return $sce.trustAsResourceUrl(content);
       }
 
-      return $interpolate('{{content}}/{{version}}/{{data}}')({
+      return $interpolate('{{content}}/{{module}}/{{version}}/{{data}}')({
         content: manifest.content,
+        module: $state.params.module || '',
         version: $state.params.version,
         data: content
       });

--- a/site/src/app/home/home.controller.js
+++ b/site/src/app/home/home.controller.js
@@ -6,11 +6,25 @@
     .controller('HomeCtrl', HomeCtrl);
 
   /** @ngInject */
-  function HomeCtrl(manifest, latestRelease) {
+  function HomeCtrl(manifest, latestRelease, util) {
     var home = this;
 
     home.contentUrl = [manifest.content, manifest.home].join('/');
     home.latestRelease = latestRelease;
+
+    if (!manifest.modules) {
+      return;
+    }
+
+    var module = util.findWhere(manifest.modules, {
+      id: manifest.defaultModule
+    });
+
+    home.module = {
+      name: module.id,
+      version: module.versions[0],
+      service: module.defaultService
+    };
   }
 
 }());

--- a/site/src/app/home/home.route.js
+++ b/site/src/app/home/home.route.js
@@ -18,8 +18,8 @@
 
   /** @ngInject */
   function getLatestRelease($http, manifest) {
-    var endpoint = 'https://api.github.com/repos/GoogleCloudPlatform/gcloud-' +
-      manifest.lang + '/releases/latest';
+    var endpoint = 'https://api.github.com/repos/GoogleCloudPlatform/' +
+      manifest.moduleName + '/releases/latest';
 
     return $http.get(endpoint)
       .then(function(response) {

--- a/site/src/app/index.run.js
+++ b/site/src/app/index.run.js
@@ -7,6 +7,10 @@
 
   /** @ngInject */
   function runBlock($state, $rootScope, manifest) {
+    if (!manifest.moduleName) {
+      manifest.moduleName = 'gcloud-' + manifest.lang;
+    }
+
     angular.extend($rootScope, manifest);
 
     $rootScope.$on('$stateChangeError', function() {

--- a/site/src/app/index.run.js
+++ b/site/src/app/index.run.js
@@ -6,7 +6,7 @@
     .run(runBlock);
 
   /** @ngInject */
-  function runBlock($state, $rootScope, manifest) {
+  function runBlock($state, $rootScope, $timeout, manifest, util) {
     if (!manifest.moduleName) {
       manifest.moduleName = 'gcloud-' + manifest.lang;
     }
@@ -17,9 +17,27 @@
       // uncomment for debugging
       // console.log(arguments);
 
+      var moduleId = $state.params.module || manifest.defaultModule;
+
+      if (!moduleId && manifest.modules) {
+        moduleId = manifest.modules[0].id;
+      }
+
+      var module;
+
+      if (moduleId) {
+        module = util.findWhere(manifest.modules, {
+          id: moduleId
+        });
+      }
+
+      var version = (module ? module : manifest).versions[0];
+      var serviceId = (module ? module : manifest).defaultService || 'gcloud';
+
       $state.go('docs.service', {
-        version: $state.params.version,
-        serviceId: manifest.defaultService || 'gcloud'
+        module: moduleId,
+        version: version,
+        serviceId: serviceId
       });
     });
   }

--- a/site/src/app/service/service.controller.js
+++ b/site/src/app/service/service.controller.js
@@ -15,7 +15,7 @@
       .map(DocsService.setAsTrusted)
       .sort(sortMethods);
 
-    service.libraryTitle = manifest.libraryTitle || 'gcloud';
+    service.libraryTitle = manifest.libraryTitle || 'Google Cloud';
     service.methodNames = service.methods.map(getName);
     service.showGettingStarted = false;
 

--- a/site/src/app/service/service.html
+++ b/site/src/app/service/service.html
@@ -86,7 +86,7 @@
       <h4>More Information</h4>
       <ul class="resource-links">
         <li>
-          <a ng-href="https://github.com/GoogleCloudPlatform/gcloud-{{lang}}/blob/{{docs.version}}/{{method.source}}">Source Code</a>
+          <a ng-href="https://github.com/GoogleCloudPlatform/{{moduleName}}/blob/{{docs.version}}/{{method.source}}">Source Code</a>
         </li>
         <li ng-repeat="resource in method.resources">
           <a ng-href="{{resource.link}}">{{resource.title}}</a>

--- a/site/src/app/service/service.html
+++ b/site/src/app/service/service.html
@@ -1,7 +1,7 @@
 <page-header title="service.title"></page-header>
 <version-switcher class="invisible-lg side-nav--meta--top"></version-switcher>
 <article class="content">
-  <div ng-if="docs.overviewFileUrl">
+  <div ng-if="::(docs.overviewFileUrl || service.overview)">
     <h3 class="sub-heading toggle" ng-click="service.showGettingStarted = !service.showGettingStarted">
       <div class="toggler">
         <span ng-if="!service.showGettingStarted">▹</span>
@@ -11,9 +11,12 @@
         Getting Started
       </span>
     </h3>
-    <article
+    <article ng-if="::docs.overviewFileUrl"
       ng-show="service.showGettingStarted"
       ng-include="docs.overviewFileUrl"></article>
+    <article ng-if="::service.overview"
+      ng-show="service.showGettingStarted"
+      bind-html-compile="service.overview"></article>
     <hr />
   </div>
   <article ng-if="service.description || service.resources.length" class="description">

--- a/site/src/app/styles/_main.scss
+++ b/site/src/app/styles/_main.scss
@@ -411,6 +411,7 @@ ul {
     top: 3.6em;
     right: 0;
     width: 100%;
+    max-height: 400px;
     bottom: 0;
     overflow-y: auto;
     margin: 0;
@@ -1478,10 +1479,10 @@ ul {
 
     .dropdown-current {
         position: relative;
-        top: 0 !important;
+        top: -5px !important;
         left: 0;
         padding: 0.8em 1.6em;
-        min-width: 122px;
+        min-width: 150px;
         width: auto;
         height: auto;
         border: 1px solid rgba(255,255,255,0.4);
@@ -1490,7 +1491,7 @@ ul {
     }
 
     .page-header.fixed .dropdown-current {
-        top: 0;
+        top: 0 !important;
         padding: 0 3.4em 0 1.6em;
         // padding: 0 1.6em;
         height: 70px;

--- a/site/src/app/styles/_main.scss
+++ b/site/src/app/styles/_main.scss
@@ -389,7 +389,7 @@ ul {
  Menu
 */
 
-.nav-current {
+.dropdown-current {
     display: block;
     position: absolute;
     top: 1.2em;
@@ -401,7 +401,7 @@ ul {
     cursor: pointer;
 }
 
-.page-header.fixed .nav-current {
+.page-header.fixed .dropdown-current {
     top: 1em;
 }
 
@@ -432,6 +432,24 @@ ul {
     position: absolute;
     bottom: initial;
     z-index: 1;
+}
+
+.language-switcher.dropdown {
+  margin-right: 0;
+}
+
+.module-switcher.dropdown {
+  margin-left: 0;
+
+  .module-name {
+    display: block;
+    white-space: nowrap;
+  }
+
+  .module-version {
+    display: block;
+    font-size: 0.8em;
+  }
 }
 
 .page-header.fixed .menu {
@@ -484,11 +502,11 @@ ul {
  Open Menu
  */
 
-.main-nav.open .nav-current {
+.dropdown.open .dropdown-current {
     opacity: 0.4;
 }
 
-.main-nav.open .menu {
+.dropdown.open .menu {
     display: block;
 }
 
@@ -1361,7 +1379,7 @@ ul {
         top: 20px;
     }
 
-    .nav-current {
+    .dropdown-current {
         top: 26px !important;
     }
 
@@ -1449,31 +1467,28 @@ ul {
         position: absolute;
     }
 
-    .main-nav {
+    .dropdown {
         margin: 0 1.3em;
-        position: absolute;
-        top: 1.2em;
+        position: relative
     }
 
-    .page-header.fixed .main-nav {
-        top: 0;
-    }
-
-    .nav-current {
+    .dropdown-current {
         position: relative;
         top: 0 !important;
         left: 0;
         padding: 0.8em 1.6em;
-        width: 150px;
+        min-width: 122px;
+        width: auto;
         height: auto;
         border: 1px solid rgba(255,255,255,0.4);
         background: url(../assets/images/icon-dropdown.svg) 90% 50% no-repeat;
         text-indent: 0;
     }
 
-    .page-header.fixed .nav-current {
+    .page-header.fixed .dropdown-current {
         top: 0;
-        padding: 0 1.6em;
+        padding: 0 3.4em 0 1.6em;
+        // padding: 0 1.6em;
         height: 70px;
         border: 1px solid rgba(255,255,255,0.2);
         border-top: none;
@@ -1481,7 +1496,7 @@ ul {
         line-height: 70px;
     }
 
-    .nav-current:hover {
+    .dropdown-current:hover {
         background-color: rgba(255,255,255,0.1);
     }
 

--- a/site/src/app/styles/_main.scss
+++ b/site/src/app/styles/_main.scss
@@ -441,6 +441,10 @@ ul {
 .module-switcher.dropdown {
   margin-left: 0;
 
+  .dropdown-current {
+    border-left: none !important;
+  }
+
   .module-name {
     display: block;
     white-space: nowrap;

--- a/site/src/index.html
+++ b/site/src/index.html
@@ -52,7 +52,9 @@
           .then(function(response) {
             angular
               .module('gcloud.manifest', [])
-              .constant('manifest', response.data);
+              .constant('manifest', angular.extend({
+                defaultPackage: ''
+              }, response.data));
 
             angular.element(document)
               .ready(function() {

--- a/site/src/index.html
+++ b/site/src/index.html
@@ -53,7 +53,7 @@
             angular
               .module('gcloud.manifest', [])
               .constant('manifest', angular.extend({
-                defaultPackage: ''
+                defaultModule: ''
               }, response.data));
 
             angular.element(document)


### PR DESCRIPTION
Closes #52 

This PR aims to add support for multiple modules while also upholding the old way of doing docs.

## Notable Changes

### manifest.json

The big change here is the addition of the `modules` key, this will be an array of modules that can be viewed. Each module should include a default service to be routed to as well as all available versions of said module.

You can specify the default module with the new `defaultModule` key.

```json
{
  "lang": "node",
  "friendlyLang": "Node.js",
  "markdown": "javascript",
  "titleDelimiter": "::",
  "defaultModule": "google-cloud",
  "moduleName": "gcloud-node",
  "content": "json",
  "home": "home.html",
  "package": {
    "title": "npm",
    "href": "https://www.npmjs.com/package/gcloud"
  },
  "modules": [{
    "id": "google-cloud",
    "name": "google-cloud",
    "defaultService": "gcloud",
    "versions": [
      "v0.29.0",
      "v0.10.0",
      "master"
    ]
  }, {
    "id": "bigquery",
    "name": "google-cloud-bigquery",
    "defaultService": "bigquery",
    "versions": [
      "v0.10.0",
      "master"
    ]
  }]
}
```

You'll also notice a `moduleName` key - this is for when `gcloud` goes away. Rather than the app trying to guess your repo name/stackoverflow tag, I thought it would be best to provide it in the manifest.json.

### Folder Hierarchy 

To support multiple modules a folder hierarchy change was needed, here is a rough example of how the JSON files should be laid out.

```sh
 ├─── google-cloud
 |     └─── master
 |           ├─── index.json
 |           ├─── types.json
 |           ├─── toc.json
 |           └─── vision
 |                 └─── index.json
 └─── vision
       ├─── master
       |     ├─── index.json
       |     ├─── types.json
       |     └─── toc.json
       └─── v0.2.0
             ├─── index.json
             ├─── types.json
             └─── toc.json
```

The obvious thing here being that since each version of each module should viewable, that means we'll need a table of contents and a list of available types per version.

### URL Changes

Previously all the links in our docs resembled something like

`/gcloud-{lang}/#/docs/{version}/{module}/{object}`

Now it will look like

`/gcloud-{lang}/#/docs/{module}/{version}/{object}`

## TODO

- [x] Update JSON Schema
- [x] Add routing support for individual modules
- [x] Documentation
- [x] Linking to modules via `custom-type` directive
- [x] Dropdown directive
- [x] Remove `gcloud` references

## Demo

Source files - https://github.com/callmehiphop/gcloud-common-modular
[Demo](https://callmehiphop.github.io/gcloud-common-modular/#/docs/google-cloud/v0.29.0/gcloud)


