### PR TITLE
Expose description on method return

### DIFF
--- a/site/src/app/docs/docs.service.js
+++ b/site/src/app/docs/docs.service.js
@@ -51,7 +51,10 @@
     }
 
     function trustReturn(returnValue) {
-      return $sce.trustAsHtml(returnValue.types.join(', '));
+      return $sce.trustAsHtml([
+        returnValue.types.join(', '),
+        returnValue.description
+      ].join(''));
     }
 
     function trustExample(example) {


### PR DESCRIPTION
Add the return description, if set, after the type. Description is rendered on a different line because the markdown parser wraps it in a paragraph tag.

![screen shot 2016-08-18 at 3 46 23 pm](https://cloud.githubusercontent.com/assets/89034/17788294/f05b5afc-655a-11e6-909e-43e6ad69caaa.png)

Without description, no change:

![screen shot 2016-08-18 at 3 48 44 pm](https://cloud.githubusercontent.com/assets/89034/17788363/493bae2e-655b-11e6-86d9-e7b2be24dd32.png)

(Those screenshots are from different methods)