### PR TITLE
Fix navigation expansion by not splitting serviceId.

### DIFF
--- a/site/src/app/docs/docs.controller.js
+++ b/site/src/app/docs/docs.controller.js
@@ -38,7 +38,6 @@
     }
 
     function isActive(serviceId) {
-      serviceId = serviceId.split('/')[0];
       return !!($state.params.serviceId || '').match(serviceId);
     }
 


### PR DESCRIPTION
Fixes  side navigation always being expanded and not collapsing.