### PR TITLE
gcloud-node -> google-cloud-node in deploy-docs.sh.

### DIFF
--- a/deploy-docs.sh
+++ b/deploy-docs.sh
@@ -76,5 +76,5 @@ function deploy_docs {
   rm -rf ../.git/modules/gh-pages
 }
 
-deploy_docs "googlecloudplatform/gcloud-node"
+deploy_docs "googlecloudplatform/google-cloud-node"
 deploy_docs "googlecloudplatform/gcloud-python"


### PR DESCRIPTION
@callmehiphop per us talking about this earlier and @stephenplusplus [mentioning](https://github.com/GoogleCloudPlatform/gcloud-common/pull/168#discussion_r75883190) it.

Github has repo redirects appear to stay in place until you make a new repo of the same name as the one you renamed. So in theory it looks like the redirect would last a long time.