### PR TITLE
Change gcloud-ruby to google-cloud-ruby in docsite updates

### DIFF
--- a/deploy-docs.sh
+++ b/deploy-docs.sh
@@ -78,4 +78,4 @@ function deploy_docs {
 
 deploy_docs "googlecloudplatform/google-cloud-node"
 deploy_docs "googlecloudplatform/gcloud-python"
-deploy_docs "googlecloudplatform/gcloud-ruby"
+deploy_docs "googlecloudplatform/google-cloud-ruby"


### PR DESCRIPTION
Repo renamed: https://github.com/GoogleCloudPlatform/google-cloud-ruby/

[refs #172]