### PR TITLE
Remove google-cloud-python from deploy-docs.sh.

### DIFF
--- a/deploy-docs.sh
+++ b/deploy-docs.sh
@@ -77,5 +77,4 @@ function deploy_docs {
 }
 
 deploy_docs "googlecloudplatform/google-cloud-node"
-deploy_docs "googlecloudplatform/gcloud-python"
 deploy_docs "googlecloudplatform/google-cloud-ruby"


### PR DESCRIPTION
We're switching back to sphinx for a little while.

I'll submit a PR to turn this back on when we're rolling again.