### PR TITLE
Update references to `gcloud-*` repos in guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 Get up and running with your Google Cloud Platform client library.
 
-  - Go - [gcloud-golang](https://github.com/googlecloudplatform/gcloud-golang)
-  - Java - [gcloud-java](https://github.com/googlecloudplatform/gcloud-java)
-  - Node.js - [gcloud-node](https://github.com/googlecloudplatform/gcloud-node)
-  - PHP - [gcloud-php](https://github.com/googlecloudplatform/gcloud-php)
-  - Python - [gcloud-python](https://github.com/googlecloudplatform/gcloud-python)
-  - Ruby - [gcloud-ruby](https://github.com/googlecloudplatform/gcloud-ruby)
+  - C# - [google-cloud-dotnet](https://github.com/googlecloudplatform/google-cloud-dotnet)
+  - Go - [google-cloud-go](https://github.com/googlecloudplatform/google-cloud-go)
+  - Java - [google-cloud-java](https://github.com/googlecloudplatform/google-cloud-java)
+  - Node.js - [google-cloud-node](https://github.com/googlecloudplatform/google-cloud-node)
+  - PHP - [google-cloud-php](https://github.com/googlecloudplatform/google-cloud-php)
+  - Python - [google-cloud-python](https://github.com/googlecloudplatform/google-cloud-python)
+  - Ruby - [google-cloud-ruby](https://github.com/googlecloudplatform/google-cloud-ruby)
 
 #### [Authentication Guide](authentication/readme.md)
 
@@ -15,10 +16,9 @@ How to enable the correct APIs for your project, create a service account, gener
 
 #### [Frequently Asked Questions](faq/readme.md)
 
-Common questions about using the gcloud client libraries, including:
+Common questions about using the google-cloud client libraries, including:
 
   - [What's the difference between Project Name and Project ID?](faq/readme.md#project-terms)
-  - [What's the relationship between gcloud-* and the gcloud command-line tool?](faq/readme.md#gcloud-sdk)
 
 #### [Troubleshooting](troubleshooting/readme.md)
 

--- a/contributing/readme.md
+++ b/contributing/readme.md
@@ -1,8 +1,8 @@
-# How to contribute to gcloud
+# How to contribute to Google Cloud
 
-Thank you for your interest in contributing to [gcloud](https://github.com/GoogleCloudPlatform). The APIs of the [Google Cloud Platform](https://cloud.google.com/) constitute a huge offering that continues to expand at a rapid pace. Because there is so much work to do to make the gcloud libraries the best-ever way to access these APIs, we desperately need your help. Your contributions are more than just welcome, they are essential.
+Thank you for your interest in contributing to [Google Cloud](https://github.com/GoogleCloudPlatform). The APIs of the [Google Cloud Platform](https://cloud.google.com/) constitute a huge offering that continues to expand at a rapid pace. Because there is so much work to do to make the Google Cloud libraries the best-ever way to access these APIs, we desperately need your help. Your contributions are more than just welcome, they are essential.
 
-Therefore, out of respect for your time and effort, we are trying hard to make contributing to gcloud a safe, efficient, and well-defined process. If you encounter any difficulty during the process, do not hesitate to [get in touch](/troubleshooting/readme.md).
+Therefore, out of respect for your time and effort, we are trying hard to make contributing to Google Cloud a safe, efficient, and well-defined process. If you encounter any difficulty during the process, do not hesitate to [get in touch](/troubleshooting/readme.md).
 
 ## Signing the Contributor License Agreement (CLA)
 
@@ -17,7 +17,7 @@ You (and your authorized signer, if corporate) can sign the CLA electronically. 
 
 ## Opening an issue
 
-If you've tried everything in our [Troubleshooting](/troubleshooting/readme.md) guide and are still running into problems, it is probably time to open a GitHub issue. GitHub provides a guide, [Mastering Issues](https://guides.github.com/features/issues/), that is useful if you are unfamiliar with the process. Here are the specific steps for opening a gcloud issue:
+If you've tried everything in our [Troubleshooting](/troubleshooting/readme.md) guide and are still running into problems, it is probably time to open a GitHub issue. GitHub provides a guide, [Mastering Issues](https://guides.github.com/features/issues/), that is useful if you are unfamiliar with the process. Here are the specific steps for opening a Google Cloud issue:
 
 1. Go to the project issues page on GitHub.
 1. Click the green `New Issue` button located in the upper right corner.
@@ -41,9 +41,9 @@ The GitHub project issues page is the place to look for shovel-ready work. Here 
 
 If you can't find anything actionable, be sure to check back again in a week or so.
 
-## Making changes to gcloud
+## Making changes to Google Cloud
 
-The following is a high-level overview of how to contribute to a gcloud client library:
+The following is a high-level overview of how to contribute to a Google Cloud client library:
 
 1. [Open an issue](#opening-an-issue) to ensure that your work is coordinated with the efforts of others.
 

--- a/contributing/readme.md
+++ b/contributing/readme.md
@@ -1,8 +1,8 @@
 # How to contribute to Google Cloud
 
-Thank you for your interest in contributing to [Google Cloud](https://github.com/GoogleCloudPlatform). The APIs of the [Google Cloud Platform](https://cloud.google.com/) constitute a huge offering that continues to expand at a rapid pace. Because there is so much work to do to make the Google Cloud libraries the best-ever way to access these APIs, we desperately need your help. Your contributions are more than just welcome, they are essential.
+Thank you for your interest in contributing to [Google Cloud](https://github.com/GoogleCloudPlatform). The APIs of the [Google Cloud Platform](https://cloud.google.com/) constitute a huge offering that continues to expand at a rapid pace. Because there is so much work to do to make the Google Cloud client libraries the best-ever way to access these APIs, we desperately need your help. Your contributions are more than just welcome, they are essential.
 
-Therefore, out of respect for your time and effort, we are trying hard to make contributing to Google Cloud a safe, efficient, and well-defined process. If you encounter any difficulty during the process, do not hesitate to [get in touch](/troubleshooting/readme.md).
+Therefore, out of respect for your time and effort, we are trying hard to make contributing a safe, efficient, and well-defined process. If you encounter any difficulty during the process, do not hesitate to [get in touch](/troubleshooting/readme.md).
 
 ## Signing the Contributor License Agreement (CLA)
 
@@ -17,7 +17,7 @@ You (and your authorized signer, if corporate) can sign the CLA electronically. 
 
 ## Opening an issue
 
-If you've tried everything in our [Troubleshooting](/troubleshooting/readme.md) guide and are still running into problems, it is probably time to open a GitHub issue. GitHub provides a guide, [Mastering Issues](https://guides.github.com/features/issues/), that is useful if you are unfamiliar with the process. Here are the specific steps for opening a Google Cloud issue:
+If you've tried everything in our [Troubleshooting](/troubleshooting/readme.md) guide and are still running into problems, it is probably time to open a GitHub issue. GitHub provides a guide, [Mastering Issues](https://guides.github.com/features/issues/), that is useful if you are unfamiliar with the process. Here are the specific steps for opening an issue:
 
 1. Go to the project issues page on GitHub.
 1. Click the green `New Issue` button located in the upper right corner.

--- a/faq/readme.md
+++ b/faq/readme.md
@@ -6,9 +6,9 @@
 The Project Name is a user-friendly name, while the Project ID is required by the gcloud client libraries to authenticate API requests.
 
 <a name="gcloud-sdk"></a>
-## What's the relationship between gcloud-* and the gcloud command-line tool?
+## What's the relationship between google-cloud-* and the gcloud command-line tool?
 
-The [`gcloud` command-line tool][gcloud-cli] and the `gcloud-*` client libraries are a part of the Google Cloud SDK: a collection of tools and libraries that enable you to easily create and manage resources on the Google Cloud Platform. The `gcloud` command-line tool can be used to manage both your development workflow and your Google Cloud Platform resources while the `gcloud-*` are language specific client libraies for various Google Cloud Platform services.
+The [`gcloud` command-line tool][gcloud-cli] and the `google-cloud-*` client libraries are a part of the Google Cloud SDK: a collection of tools and libraries that enable you to easily create and manage resources on the Google Cloud Platform. The `gcloud` command-line tool can be used to manage both your development workflow and your Google Cloud Platform resources while the `google-cloud-*` are language specific client libraies for various Google Cloud Platform services.
 
 
 [gcloud-cli]: https://cloud.google.com/sdk/gcloud/

--- a/faq/readme.md
+++ b/faq/readme.md
@@ -3,12 +3,4 @@
 <a name="project-terms"></a>
 ## What's the difference between "Project Name" and "Project ID"?
 
-The Project Name is a user-friendly name, while the Project ID is required by the gcloud client libraries to authenticate API requests.
-
-<a name="gcloud-sdk"></a>
-## What's the relationship between google-cloud-* and the gcloud command-line tool?
-
-The [`gcloud` command-line tool][gcloud-cli] and the `google-cloud-*` client libraries are a part of the Google Cloud SDK: a collection of tools and libraries that enable you to easily create and manage resources on the Google Cloud Platform. The `gcloud` command-line tool can be used to manage both your development workflow and your Google Cloud Platform resources while the `google-cloud-*` are language specific client libraies for various Google Cloud Platform services.
-
-
-[gcloud-cli]: https://cloud.google.com/sdk/gcloud/
+The Project Name is a user-friendly name, while the Project ID is required by the Google Cloud client libraries to authenticate API requests.

--- a/troubleshooting/readme.md
+++ b/troubleshooting/readme.md
@@ -38,13 +38,12 @@ If you're experiencing a bug with the code, or have an idea for how it can be im
   - [`google-cloud-python` on GitHub][gh-python]
   - [`google-cloud-ruby` on GitHub][gh-ruby]
 
-
-[so-golang]: http://stackoverflow.com/questions/tagged/gcloud-go
-[so-java]: http://stackoverflow.com/questions/tagged/gcloud-java
-[so-node]: http://stackoverflow.com/questions/tagged/gcloud-node
-[so-php]: http://stackoverflow.com/questions/tagged/gcloud-php
-[so-python]: http://stackoverflow.com/questions/tagged/gcloud-python
-[so-ruby]: http://stackoverflow.com/questions/tagged/gcloud-ruby
+[so-golang]: http://stackoverflow.com/questions/tagged/google-cloud-platform+go
+[so-java]: http://stackoverflow.com/questions/tagged/google-cloud-platform+java
+[so-node]: http://stackoverflow.com/questions/tagged/google-cloud-platform+node
+[so-php]: http://stackoverflow.com/questions/tagged/google-cloud-platform+php
+[so-python]: http://stackoverflow.com/questions/tagged/google-cloud-platform+python
+[so-ruby]: http://stackoverflow.com/questions/tagged/google-cloud-platform+ruby
 
 [gh-search-golang]: https://github.com/googlecloudplatform/google-cloud-go/issues?&q=
 [gh-search-java]: https://github.com/googlecloudplatform/google-cloud-java/issues?&q=

--- a/troubleshooting/readme.md
+++ b/troubleshooting/readme.md
@@ -5,7 +5,7 @@
 
 ### Ask the Community
 
-If you have a question about how to use a gcloud client library in your project or are stuck in the Developer's console and don't know where to turn, it's possible your questions have already been addressed by the community.
+If you have a question about how to use a Google Cloud client library in your project or are stuck in the Developer's console and don't know where to turn, it's possible your questions have already been addressed by the community.
 
 First, check out the appropriate tag on StackOverflow:
 
@@ -18,12 +18,12 @@ First, check out the appropriate tag on StackOverflow:
 
 Next, try searching through the issues on GitHub:
 
-  - [`gcloud-golang` Issues on GitHub][gh-search-golang]
-  - [`gcloud-java` Issues on GitHub][gh-search-java]
-  - [`gcloud-node` Issues on GitHub][gh-search-node]
-  - [`gcloud-php` Issues on GitHub][gh-search-php]
-  - [`gcloud-python` Issues on GitHub][gh-search-python]
-  - [`gcloud-ruby` Issues on GitHub][gh-search-ruby]
+  - [`google-cloud-go` Issues on GitHub][gh-search-golang]
+  - [`google-cloud-java` Issues on GitHub][gh-search-java]
+  - [`google-cloud-node` Issues on GitHub][gh-search-node]
+  - [`google-cloud-php` Issues on GitHub][gh-search-php]
+  - [`google-cloud-python` Issues on GitHub][gh-search-python]
+  - [`google-cloud-ruby` Issues on GitHub][gh-search-ruby]
 
 Still nothing?
 
@@ -31,12 +31,12 @@ Still nothing?
 
 If you're experiencing a bug with the code, or have an idea for how it can be improved, *please* create a new issue on GitHub so we can talk about it.
 
-  - [`gcloud-golang` on GitHub][gh-golang]
-  - [`gcloud-java` on GitHub][gh-java]
-  - [`gcloud-node` on GitHub][gh-node]
-  - [`gcloud-php` on GitHub][gh-php]
-  - [`gcloud-python` on GitHub][gh-python]
-  - [`gcloud-ruby` on GitHub][gh-ruby]
+  - [`google-cloud-go` on GitHub][gh-golang]
+  - [`google-cloud-java` on GitHub][gh-java]
+  - [`google-cloud-node` on GitHub][gh-node]
+  - [`google-cloud-php` on GitHub][gh-php]
+  - [`google-cloud-python` on GitHub][gh-python]
+  - [`google-cloud-ruby` on GitHub][gh-ruby]
 
 
 [so-golang]: http://stackoverflow.com/questions/tagged/gcloud-go
@@ -46,16 +46,16 @@ If you're experiencing a bug with the code, or have an idea for how it can be im
 [so-python]: http://stackoverflow.com/questions/tagged/gcloud-python
 [so-ruby]: http://stackoverflow.com/questions/tagged/gcloud-ruby
 
-[gh-search-golang]: https://github.com/googlecloudplatform/gcloud-golang/issues?&q=
-[gh-search-java]: https://github.com/googlecloudplatform/gcloud-java/issues?&q=
-[gh-search-node]: https://github.com/googlecloudplatform/gcloud-node/issues?&q=
-[gh-search-php]: https://github.com/googlecloudplatform/gcloud-php/issues?&q=
-[gh-search-python]: https://github.com/googlecloudplatform/gcloud-python/issues?&q=
-[gh-search-ruby]: https://github.com/googlecloudplatform/gcloud-ruby/issues?&q=
+[gh-search-golang]: https://github.com/googlecloudplatform/google-cloud-go/issues?&q=
+[gh-search-java]: https://github.com/googlecloudplatform/google-cloud-java/issues?&q=
+[gh-search-node]: https://github.com/googlecloudplatform/google-cloud-node/issues?&q=
+[gh-search-php]: https://github.com/googlecloudplatform/google-cloud-php/issues?&q=
+[gh-search-python]: https://github.com/googlecloudplatform/google-cloud-python/issues?&q=
+[gh-search-ruby]: https://github.com/googlecloudplatform/google-cloud-ruby/issues?&q=
 
-[gh-golang]: https://github.com/googlecloudplatform/gcloud-golang/issues/new
-[gh-java]: https://github.com/googlecloudplatform/gcloud-java/issues/new
-[gh-node]: https://github.com/googlecloudplatform/gcloud-node/issues/new
-[gh-php]: https://github.com/googlecloudplatform/gcloud-php/issues/new
-[gh-python]: https://github.com/googlecloudplatform/gcloud-python/issues/new
-[gh-ruby]: https://github.com/googlecloudplatform/gcloud-ruby/issues/new
+[gh-golang]: https://github.com/googlecloudplatform/google-cloud-go/issues/new
+[gh-java]: https://github.com/googlecloudplatform/google-cloud-java/issues/new
+[gh-node]: https://github.com/googlecloudplatform/google-cloud-node/issues/new
+[gh-php]: https://github.com/googlecloudplatform/google-cloud-php/issues/new
+[gh-python]: https://github.com/googlecloudplatform/google-cloud-python/issues/new
+[gh-ruby]: https://github.com/googlecloudplatform/google-cloud-ruby/issues/new

--- a/troubleshooting/readme.md
+++ b/troubleshooting/readme.md
@@ -9,15 +9,17 @@ If you have a question about how to use a Google Cloud client library in your pr
 
 First, check out the appropriate tag on StackOverflow:
 
-  - [`gcloud-golang` on StackOverflow][so-golang]
-  - [`gcloud-java` on StackOverflow][so-java]
-  - [`gcloud-node` on StackOverflow][so-node]
-  - [`gcloud-php` on StackOverflow][so-php]
-  - [`gcloud-python` on StackOverflow][so-python]
-  - [`gcloud-ruby` on StackOverflow][so-ruby]
+  - [`google-cloud-platform+c#` on StackOverflow][so-dotnet]
+  - [`google-cloud-platform+golang` on StackOverflow][so-golang]
+  - [`google-cloud-platform+java` on StackOverflow][so-java]
+  - [`google-cloud-platform+node` on StackOverflow][so-node]
+  - [`google-cloud-platform+php` on StackOverflow][so-php]
+  - [`google-cloud-platform+python` on StackOverflow][so-python]
+  - [`google-cloud-platform+ruby` on StackOverflow][so-ruby]
 
 Next, try searching through the issues on GitHub:
 
+  - [`google-cloud-dotnet` Issues on GitHub][gh-search-dotnet]
   - [`google-cloud-go` Issues on GitHub][gh-search-golang]
   - [`google-cloud-java` Issues on GitHub][gh-search-java]
   - [`google-cloud-node` Issues on GitHub][gh-search-node]
@@ -31,6 +33,7 @@ Still nothing?
 
 If you're experiencing a bug with the code, or have an idea for how it can be improved, *please* create a new issue on GitHub so we can talk about it.
 
+  - [`google-cloud-dotnet` on GitHub][gh-dotnet]
   - [`google-cloud-go` on GitHub][gh-golang]
   - [`google-cloud-java` on GitHub][gh-java]
   - [`google-cloud-node` on GitHub][gh-node]
@@ -38,6 +41,7 @@ If you're experiencing a bug with the code, or have an idea for how it can be im
   - [`google-cloud-python` on GitHub][gh-python]
   - [`google-cloud-ruby` on GitHub][gh-ruby]
 
+[so-dotnet]: http://stackoverflow.com/questions/tagged/google-cloud-platform+c%23
 [so-golang]: http://stackoverflow.com/questions/tagged/google-cloud-platform+go
 [so-java]: http://stackoverflow.com/questions/tagged/google-cloud-platform+java
 [so-node]: http://stackoverflow.com/questions/tagged/google-cloud-platform+node
@@ -45,6 +49,7 @@ If you're experiencing a bug with the code, or have an idea for how it can be im
 [so-python]: http://stackoverflow.com/questions/tagged/google-cloud-platform+python
 [so-ruby]: http://stackoverflow.com/questions/tagged/google-cloud-platform+ruby
 
+[gh-search-dotnet]: https://github.com/googlecloudplatform/google-cloud-dotnet/issues?&q=
 [gh-search-golang]: https://github.com/googlecloudplatform/google-cloud-go/issues?&q=
 [gh-search-java]: https://github.com/googlecloudplatform/google-cloud-java/issues?&q=
 [gh-search-node]: https://github.com/googlecloudplatform/google-cloud-node/issues?&q=
@@ -52,6 +57,7 @@ If you're experiencing a bug with the code, or have an idea for how it can be im
 [gh-search-python]: https://github.com/googlecloudplatform/google-cloud-python/issues?&q=
 [gh-search-ruby]: https://github.com/googlecloudplatform/google-cloud-ruby/issues?&q=
 
+[gh-dotnet]: https://github.com/googlecloudplatform/google-cloud-dotnet/issues/new
 [gh-golang]: https://github.com/googlecloudplatform/google-cloud-go/issues/new
 [gh-java]: https://github.com/googlecloudplatform/google-cloud-java/issues/new
 [gh-node]: https://github.com/googlecloudplatform/google-cloud-node/issues/new


### PR DESCRIPTION
Updated the `gcloud-*` references to `google-cloud-*` and `gcloud` to `Google Cloud`. I left the stack overflow tags as-is, because it does not seem that those have changed. I can update if needed.
