### PR TITLE
site: added release notes link

### DIFF
--- a/site/src/app/components/version-switcher/version-switcher.directive.spec.js
+++ b/site/src/app/components/version-switcher/version-switcher.directive.spec.js
@@ -1,0 +1,77 @@
+(function() {
+  'use strict';
+
+  describe('version-switcher', function() {
+    var FAKE_MODULE_NAME = 'google-cloud-wat';
+    var FAKE_TAG = 'bigquery-0.1.0';
+    var FAKE_VERSIONS = [
+      '0.36.0',
+      '0.35.0',
+      'master'
+    ];
+
+    var el;
+    var $compile;
+    var $scope;
+
+    beforeEach(function() {
+      module('gcloud.manifest', function($provide) {
+        $provide.constant('manifest', {
+          versions: []
+        });
+      });
+      module('gcloud');
+    });
+
+    beforeEach(inject(function($rootScope, $injector) {
+      $compile = $injector.get('$compile');
+      $scope = $rootScope.$new();
+
+      $scope.moduleName = FAKE_MODULE_NAME;
+
+      $scope.docs = {
+        selectedVersion: FAKE_VERSIONS[0],
+        tagName: FAKE_TAG,
+        versions: FAKE_VERSIONS
+      };
+
+      el = angular.element('<version-switcher></version-switcher>');
+    }));
+
+    it('should create a version switcher', function() {
+      $compile(el)($scope);
+      $scope.$digest();
+
+      var options = el.find('select').children();
+
+      expect(options.length).toBe(FAKE_VERSIONS.length);
+
+      FAKE_VERSIONS.forEach(function(fakeVersion, i) {
+        expect(options[i].innerText).toBe(fakeVersion);
+      });
+    });
+
+    it('should show the release notes link for releases', function() {
+      $compile(el)($scope);
+      $scope.$digest();
+
+      var expectedPath = 'https://github.com/GoogleCloudPlatform/' +
+        FAKE_MODULE_NAME + '/releases/tag/' + FAKE_TAG;
+
+      var releaseNotes = el.find('a');
+
+      expect(releaseNotes.attr('href')).toBe(expectedPath);
+    });
+
+    it('should not show the release notes link for master', function() {
+      $scope.docs.selectedVersion = 'master';
+
+      $compile(el)($scope);
+      $scope.$digest();
+
+      var releaseNotes = el.find('a');
+
+      expect(releaseNotes.length).toBe(0);
+    });
+  });
+}());

--- a/site/src/app/components/version-switcher/version-switcher.html
+++ b/site/src/app/components/version-switcher/version-switcher.html
@@ -8,9 +8,18 @@
         ng-options="version for version in docs.versions"
         ng-change="docs.loadVersion(docs.selectedVersion)"
       ></select>
-      <div ng-if="selectedVersion.name === 'master' && docs.lastBuiltDate">
+<!--       <div ng-if="docs.selectedVersion === 'master' && docs.lastBuiltDate">
         <small>
           <em>Docs last built {{docs.lastBuiltDate | date : longDate}}.</em>
+        </small>
+      </div> -->
+      <div ng-if="docs.selectedVersion !== 'master'">
+        <small>
+          <em>
+            <a
+              ng-href="https://github.com/GoogleCloudPlatform/{{moduleName}}/releases/tag/{{docs.tagName}}"
+              target="_blank">Release notes</a>
+          </em>
         </small>
       </div>
     </div>

--- a/site/src/app/styles/_main.scss
+++ b/site/src/app/styles/_main.scss
@@ -1106,7 +1106,6 @@ ul {
 .side-nav--meta {
     padding: 10px;
     background-color: #f5f5f5;
-    text-align: center;
     margin-bottom: 10px;
 }
 
@@ -1115,7 +1114,7 @@ ul {
     padding-right: 2em;
 }
 
-.side-nav a {
+.side-nav ul a {
     display: block;
     padding: 0.3em 2em;
     color: #5d6061;
@@ -1128,7 +1127,7 @@ ul {
         transition: all 0.3s ease;
 }
 
-.side-nav a:hover {
+.side-nav ul a:hover {
     background: rgba(255,255,255,0.7);
 }
 
@@ -1655,7 +1654,11 @@ ul {
         overflow-y: auto;
     }
 
-    .side-nav a {
+    .side-nav--meta {
+      text-align: center;
+    }
+
+    .side-nav ul a {
         padding-left: 2.5em;
     }
 }


### PR DESCRIPTION
This adds a link for the release notes associated with the currently viewed version.

Examples:
### Desktop

<img width="1068" alt="screen shot 2016-10-17 at 2 22 06 pm" src="https://cloud.githubusercontent.com/assets/1707267/19449974/a5b8dd86-9475-11e6-8f68-2b259a0f4b9a.png">
### Mobile

<img width="396" alt="screen shot 2016-10-17 at 2 22 17 pm" src="https://cloud.githubusercontent.com/assets/1707267/19449985/aeb754d0-9475-11e6-9b55-3a6c8259f89b.png">
