### PR TITLE
site: Add level of nesting to left nav

### DIFF
--- a/site/src/app/docs/docs.controller.js
+++ b/site/src/app/docs/docs.controller.js
@@ -38,15 +38,27 @@
       return $state.go($state.current.name, { version: version });
     }
 
-    function isActive(serviceId) {
+    function isActive(service) {
+      var serviceId = service.type;
       var serviceIdParam = $state.params.serviceId || '';
 
-      if (!manifest.matchPartialServiceId) {
-        return !!serviceIdParam.match(serviceId);
+      // Match the first element in the serviceId. E.g., nav parent
+      // `datastore/client` matches `datastore` extracted from nav child
+      // `datastore/query`.
+      if (manifest.matchPartialServiceId) {
+        var partialServiceId = serviceId.split('/')[0];
+        return !!serviceIdParam.match(partialServiceId);
+
+      // Match the downcase service title to any part of the serviceIdParam,
+      // E.g., both nav parent `google/cloud/datastore` and nav child
+      // `google/datastore/v1` match the title `datastore`.
+      } else if (manifest.matchServiceTitle)  {
+        var parts = serviceIdParam.split('/');
+        return parts.indexOf(service.title.toLowerCase()) >= 0;
       }
 
-      var partialServiceId = serviceId.split('/')[0];
-      return !!serviceIdParam.match(partialServiceId);
+      // Strictly match. E.g., `datastore/query` matches `datastore`.
+      return !!serviceIdParam.match(serviceId);
     }
 
     function getGuideUrl(page) {

--- a/site/src/app/docs/docs.html
+++ b/site/src/app/docs/docs.html
@@ -42,9 +42,14 @@
       </li>
       <li ng-repeat="service in docs.services">
         <a side-nav-link="/{{service.type}}">{{service.title || service.type}}</a>
-        <ul class="sub-sections" ng-if="service.nav && docs.isActive(service.type)">
+        <ul class="sub-sections" ng-if="service.nav && docs.isActive(service)">
           <li ng-repeat="page in service.nav">
             <a side-nav-link="/{{page.type}}">{{page.title || page.type}}</a>
+            <ul class="sub-sections-2" ng-if="page.nav && docs.isActive(page)">
+              <li ng-repeat="page_2 in page.nav">
+                <a side-nav-link="/{{page_2.type}}">{{page_2.title || page_2.type}}</a>
+              </li>
+            </ul>
           </li>
         </ul>
       </li>

--- a/site/src/app/styles/_main.scss
+++ b/site/src/app/styles/_main.scss
@@ -1151,6 +1151,10 @@ ul {
     padding-left: 4em;
 }
 
+.side-nav .sub-sections-2 a {
+    padding-left: 5.5em;
+}
+
 .side-nav .external-links {
     margin-top: 2em;
 }


### PR DESCRIPTION
[Demo](https://quartzmo.github.io/google-cloud-ruby/#/docs/google-cloud/master/google/datastore/v1)

In order to support the design in #207, this PR adds an extra level of nesting support in the left nav. I can produce a demo if needed. Here is a screenshot from my local app:

![protobuf-data-types-nav](https://cloud.githubusercontent.com/assets/205445/21461149/2e30aeb2-c90c-11e6-891b-2825a796a881.png)


[closes #209]

/cc @omaray @blowmage @swcloud