### PR TITLE
site: Add regex-based matching for left nav

### DIFF
--- a/site/schemas/toc.schema.json
+++ b/site/schemas/toc.schema.json
@@ -75,6 +75,16 @@
             "type": "string",
             "description": "ID of type that maps JSON content"
           },
+          "type": {
+            "id": "patterns",
+            "type": "array",
+            "description": "List of RegExp patterns to match URL paths. If any is matched, the left nav item for this service will be active.",
+            "items": {
+              "id": "pattern",
+              "type": "string",
+              "description": "Valid RegExp pattern string"
+            }
+          },
           "nav": {
             "id": "nav",
             "type": "array",

--- a/site/src/app/docs/docs.controller.js
+++ b/site/src/app/docs/docs.controller.js
@@ -42,22 +42,28 @@
       var serviceId = service.type;
       var serviceIdParam = $state.params.serviceId || '';
 
-      // Match the first element in the serviceId. E.g., nav parent
+      // Match the first element in the type. E.g., nav parent
       // `datastore/client` matches `datastore` extracted from nav child
       // `datastore/query`.
       if (manifest.matchPartialServiceId) {
         var partialServiceId = serviceId.split('/')[0];
         return !!serviceIdParam.match(partialServiceId);
 
-      // Match the downcase service title to any part of the serviceIdParam,
+      // If toc entry contains 'patterns', attempt to match any of them.
       // E.g., both nav parent `google/cloud/datastore` and nav child
-      // `google/datastore/v1` match the title `datastore`.
-      } else if (manifest.matchServiceTitle)  {
-        var parts = serviceIdParam.split('/');
-        return parts.indexOf(service.title.toLowerCase()) >= 0;
+      // `google/datastore/v1` match the pattern `datastore`.
+      } else if (service.patterns)  {
+        var matched = false;
+        angular.forEach(service.patterns, function(pattern) {
+          if (!matched) { // Simply skip if already matched
+            if (new RegExp(pattern).test(serviceIdParam)) {
+              matched = true;
+            }
+          }
+        });
+        return matched;
       }
-
-      // Strictly match. E.g., `datastore/query` matches `datastore`.
+      // Match using type. E.g., `datastore/query` is a match for `datastore`.
       return !!serviceIdParam.match(serviceId);
     }
 


### PR DESCRIPTION
Replace `matchServiceTitle` in `manifest.json` with `patterns` in `toc.json`.

This change supports multi-word service titles (e.g., 'Natural Language') when the name in the package path is different (e.g., `google/cloud/language`).

The new solution replaces the `matchServiceTitle` introduced in #213 with a more flexible, regexp-based approach. I believe this is safe to do because my understanding is that only google-cloud-ruby is using the `matchServiceTitle` flag.

[closes #216]