### PR TITLE
site: Update service.html to always show the available methods section

### DIFF
--- a/site/src/app/service/service.html
+++ b/site/src/app/service/service.html
@@ -38,7 +38,7 @@
     </section>
   </article>
   <article ng-repeat="method in service.methods">
-    <div ng-if="method.isConstructor" class="notice">
+    <div ng-if="$first" class="notice">
       Available methods:
       <span ng-repeat="method in service.methods">
         <a ui-sref="docs.service({ method: method.id })">{{method.name}}</a>{{$last ? '' : ', '}}


### PR DESCRIPTION
Always show available methods section. This will reveal the section in the many classes of google-cloud-ruby where the docs for the constructor are private. It should not result in a regression for other platforms, as long as constructors are public and listed first.

[fixes GoogleCloudPlatform/google-cloud-ruby#1593]